### PR TITLE
Correct Java Exception return and prepare for a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following sections provide you details on how to use the FTP connector.
 
 |                             |           Version           |
 |:---------------------------:|:---------------------------:|
-| Ballerina Language          |            1.1.2            |
+| Ballerina Language          |            1.1.4            |
 
 ## Feature Overview
 

--- a/ftp-compiler-plugin/pom.xml
+++ b/ftp-compiler-plugin/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>module-ftp</artifactId>
-        <version>0.4.3</version>
+        <version>0.4.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ftp-compiler-plugin</artifactId>
-    <version>0.4.3</version>
+    <version>0.4.4</version>
     <packaging>jar</packaging>
     <name>FTP Module - Compiler Validation Utility</name>
     <url>https://ballerina.io/</url>

--- a/ftp-utils/pom.xml
+++ b/ftp-utils/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>module-ftp</artifactId>
-        <version>0.4.3</version>
+        <version>0.4.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <version>0.4.3</version>
+    <version>0.4.4</version>
     <artifactId>ftp-utils</artifactId>
     <packaging>jar</packaging>
     <name>FTP Module - Java utility library</name>

--- a/ftp-utils/src/main/java/org/wso2/ei/b7a/ftp/core/client/FTPClient.java
+++ b/ftp-utils/src/main/java/org/wso2/ei/b7a/ftp/core/client/FTPClient.java
@@ -19,7 +19,6 @@
 package org.wso2.ei.b7a.ftp.core.client;
 
 import org.ballerinalang.jvm.BRuntime;
-import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.jvm.values.MapValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.stdlib.io.channels.base.Channel;
@@ -29,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.wso2.ei.b7a.ftp.core.util.BallerinaFTPException;
 import org.wso2.ei.b7a.ftp.core.util.FTPConstants;
 import org.wso2.ei.b7a.ftp.core.util.FTPUtil;
+import org.wso2.transport.remotefilesystem.Constants;
 import org.wso2.transport.remotefilesystem.RemoteFileSystemConnectorFactory;
 import org.wso2.transport.remotefilesystem.client.connector.contract.FtpAction;
 import org.wso2.transport.remotefilesystem.client.connector.contract.VFSClientConnector;
@@ -54,7 +54,7 @@ public class FTPClient {
         // private constructor
     }
 
-    public static void initClientEndpoint(ObjectValue clientEndpoint, MapValue<Object, Object> config)
+    public static Object initClientEndpoint(ObjectValue clientEndpoint, MapValue<Object, Object> config)
             throws BallerinaFTPException {
 
         String protocol = config.getStringValue(FTPConstants.ENDPOINT_CONFIG_PROTOCOL);
@@ -72,14 +72,29 @@ public class FTPClient {
         clientEndpoint.addNativeData(FTPConstants.ENDPOINT_CONFIG_PORT,
                 FTPUtil.extractPortValue(config.getIntValue(FTPConstants.ENDPOINT_CONFIG_PORT)));
         clientEndpoint.addNativeData(FTPConstants.ENDPOINT_CONFIG_PROTOCOL, protocol);
-        Map<String, String> ftpConfig = new HashMap<>(3);
+        Map<String, String> ftpConfig = new HashMap<>(5);
+        MapValue secureSocket = config.getMapValue(FTPConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
+        if (secureSocket != null) {
+            final MapValue privateKey = secureSocket.getMapValue(FTPConstants.ENDPOINT_CONFIG_PRIVATE_KEY);
+            if (privateKey != null) {
+                final String privateKeyPath = privateKey.getStringValue(FTPConstants.ENDPOINT_CONFIG_PATH);
+                if (privateKeyPath != null && !privateKeyPath.isEmpty()) {
+                    ftpConfig.put(Constants.IDENTITY, privateKeyPath);
+                    final String privateKeyPassword = privateKey.getStringValue(FTPConstants.ENDPOINT_CONFIG_PASS_KEY);
+                    if (privateKeyPassword != null && !privateKeyPassword.isEmpty()) {
+                        ftpConfig.put(Constants.IDENTITY_PASS_PHRASE, privateKeyPassword);
+                    }
+                }
+            }
+        }
         ftpConfig.put(FTPConstants.FTP_PASSIVE_MODE, String.valueOf(true));
         ftpConfig.put(FTPConstants.USER_DIR_IS_ROOT, String.valueOf(false));
         ftpConfig.put(FTPConstants.AVOID_PERMISSION_CHECK, String.valueOf(true));
         clientEndpoint.addNativeData(FTPConstants.PROPERTY_MAP, ftpConfig);
+        return null;
     }
 
-    public static ObjectValue get(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
+    public static Object get(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
 
         String url = FTPUtil.createUrl(clientConnector, filePath);
         Map<String, String> propertyMap = new HashMap<>(
@@ -100,7 +115,7 @@ public class FTPClient {
         return null;
     }
 
-    public static void append(ObjectValue clientConnector, MapValue<Object, Object> inputContent)
+    public static Object append(ObjectValue clientConnector, MapValue<Object, Object> inputContent)
             throws BallerinaFTPException {
 
         try {
@@ -134,9 +149,10 @@ public class FTPClient {
         } catch (RemoteFileSystemConnectorException | IOException e) {
             throw new BallerinaFTPException(e.getMessage());
         }
+        return null;
     }
 
-    public static void put(ObjectValue clientConnector, MapValue<Object, Object> inputContent)
+    public static Object put(ObjectValue clientConnector, MapValue<Object, Object> inputContent)
             throws BallerinaFTPException {
 
         Map<String, String> propertyMap = new HashMap<>(
@@ -191,9 +207,10 @@ public class FTPClient {
                 log.error("Error in closing stream");
             }
         }
+        return null;
     }
 
-    public static void delete(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
+    public static Object delete(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
 
         String url = FTPUtil.createUrl(clientConnector, filePath);
         Map<String, String> propertyMap = new HashMap<>(
@@ -212,9 +229,10 @@ public class FTPClient {
         }
         connector.send(null, FtpAction.DELETE);
         future.complete(null);
+        return null;
     }
 
-    public static boolean isDirectory(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
+    public static Object isDirectory(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
 
         String url = FTPUtil.createUrl(clientConnector, filePath);
         Map<String, String> propertyMap = new HashMap<>(
@@ -235,8 +253,7 @@ public class FTPClient {
         return false;
     }
 
-    public static ArrayValue list(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
-
+    public static Object list(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
         String url = FTPUtil.createUrl(clientConnector, filePath);
         Map<String, String> propertyMap = new HashMap<>(
                 (Map<String, String>) clientConnector.getNativeData(FTPConstants.PROPERTY_MAP));
@@ -256,7 +273,7 @@ public class FTPClient {
         return null;
     }
 
-    public static void mkdir(ObjectValue clientConnector, String path) throws BallerinaFTPException {
+    public static Object mkdir(ObjectValue clientConnector, String path) throws BallerinaFTPException {
 
         String url = FTPUtil.createUrl(clientConnector, path);
         Map<String, String> propertyMap = new HashMap<>(
@@ -275,9 +292,10 @@ public class FTPClient {
         }
         connector.send(null, FtpAction.MKDIR);
         future.complete(null);
+        return null;
     }
 
-    public static void rename(ObjectValue clientConnector, String origin, String destination)
+    public static Object rename(ObjectValue clientConnector, String origin, String destination)
             throws BallerinaFTPException {
 
         Map<String, String> propertyMap = new HashMap<>(
@@ -297,9 +315,10 @@ public class FTPClient {
         }
         connector.send(null, FtpAction.RENAME);
         future.complete(null);
+        return null;
     }
 
-    public static void rmdir(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
+    public static Object rmdir(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
 
         String url = FTPUtil.createUrl(clientConnector, filePath);
         Map<String, String> propertyMap = new HashMap<>(
@@ -318,9 +337,10 @@ public class FTPClient {
         }
         connector.send(null, FtpAction.RMDIR);
         future.complete(null);
+        return null;
     }
 
-    public static int size(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
+    public static Object size(ObjectValue clientConnector, String filePath) throws BallerinaFTPException {
 
         String url = FTPUtil.createUrl(clientConnector, filePath);
         Map<String, String> propertyMap = new HashMap<>(

--- a/ftp-utils/src/main/java/org/wso2/ei/b7a/ftp/core/util/FTPConstants.java
+++ b/ftp-utils/src/main/java/org/wso2/ei/b7a/ftp/core/util/FTPConstants.java
@@ -39,7 +39,7 @@ public class FTPConstants {
     public static final String PROPERTY_MAP = "map";
     public static final String FTP_ORG_NAME = "wso2";
     public static final String FTP_MODULE_NAME = "ftp";
-    public static final String FTP_MODULE_VERSION = "0.4.3";
+    public static final String FTP_MODULE_VERSION = "0.4.4";
     public static final String FTP_LISTENER = "Listener";
     public static final String FTP_SERVER_EVENT = "WatchEvent";
     public static final String FTP_FILE_INFO = "FileInfo";

--- a/ftp/Ballerina.lock
+++ b/ftp/Ballerina.lock
@@ -1,7 +1,7 @@
 org_name = "wso2"
 version = "0.4.3"
 lockfile_version = "1.0.0"
-ballerina_version = "1.1.2"
+ballerina_version = "1.1.4"
 
 [[imports."wso2/ftp:0.4.3"]]
 org_name = "ballerinax"

--- a/ftp/Ballerina.lock
+++ b/ftp/Ballerina.lock
@@ -1,9 +1,9 @@
 org_name = "wso2"
-version = "0.4.3"
+version = "0.4.4"
 lockfile_version = "1.0.0"
 ballerina_version = "1.1.4"
 
-[[imports."wso2/ftp:0.4.3"]]
+[[imports."wso2/ftp:0.4.4"]]
 org_name = "ballerinax"
 name = "java"
 version = "0.0.0"

--- a/ftp/Ballerina.toml
+++ b/ftp/Ballerina.toml
@@ -1,6 +1,6 @@
 [project]
 org-name= "wso2"
-version= "0.4.3"
+version= "0.4.4"
 license= ["Apache-2.0"]
 authors= ["WSO2"]
 keywords= ["ftp"]
@@ -13,7 +13,7 @@ target = "java8"
 
     [[platform.libraries]]
     module = "utils/ftp-utils"
-    path = "../ftp-utils/target/ftp-utils-module-0.4.3.jar"
+    path = "../ftp-utils/target/ftp-utils-module-0.4.4.jar"
     artifactId = "wso2-ftp"
-    version = "0.4.3"
+    version = "0.4.4"
     groupId = "org.wso2.ei"

--- a/ftp/pom.xml
+++ b/ftp/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <artifactId>module-ftp</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>0.4.3</version>
+        <version>0.4.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ftp</artifactId>
-    <version>0.4.3</version>
+    <version>0.4.4</version>
     <packaging>pom</packaging>
     <name>FTP Module - Ballerina Implementation</name>
     <url>https://ballerina.io/</url>

--- a/ftp/src/ftp/Module.md
+++ b/ftp/src/ftp/Module.md
@@ -32,7 +32,7 @@ For instance, if the listener gets invoked for text files, the value `(.*).txt` 
 
 |                             |           Version           |
 |:---------------------------:|:---------------------------:|
-| Ballerina Language          |            1.1.2            |
+| Ballerina Language          |            1.1.4            |
 
 ## Samples
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.wso2.ei</groupId>
     <artifactId>module-ftp</artifactId>
     <packaging>pom</packaging>
-    <version>0.4.3</version>
+    <version>0.4.4</version>
     <name>Ballerina - FTP Module Parent</name>
 
     <url>https://ballerina.io/</url>
@@ -191,7 +191,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <ballerina.version>1.1.0</ballerina.version>
-        <module.ftp.version>0.4.3</module.ftp.version>
+        <module.ftp.version>0.4.4</module.ftp.version>
 
         <file.transport.version>6.0.57</file.transport.version>
         <jsch.version>0.1.54</jsch.version>


### PR DESCRIPTION
## Purpose
Java return of exceptions to Ballerina side was corrected by returning `Object` type.  Fixes https://github.com/ballerina-platform/module-ballerina-ftp/issues/98.