### PR TITLE
Move ballerina Build, Test and Publishing Into a Single Task

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -1,0 +1,25 @@
+name: Publish to the Ballerina central
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'ballerina-platform'
+    steps:
+      -   uses: actions/checkout@v2
+      -   name: Set up JDK 11
+          uses: actions/setup-java@v1
+          with:
+            java-version: 11
+      -   name: Grant execute permission for gradlew
+          run: chmod +x gradlew
+      -   name: Publish artifact
+          env:
+            BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+            packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+            packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          run: |
+            ./gradlew clean build -PpublishToCentral=true

--- a/README.md
+++ b/README.md
@@ -36,28 +36,44 @@ This repository only contains the source code for the package.
 Execute the commands below to build from source.
 
 1. To build the package:
+   ```    
+   ./gradlew clean build
+   ```
 
-    ```shell script
-        ./gradlew clean build
+2. To run the tests:
+   ```
+   ./gradlew clean test
+   ```
+
+3. To run a group of tests
+   ```
+   ./gradlew clean test -Pgroups=<test_group_names>
+   ```
+
+4. To build the without the tests:
+   ```
+   ./gradlew clean build -x test
+   ```
+
+5. To debug package implementation:
+   ```
+   ./gradlew clean build -Pdebug=<port>
+   ```
+
+6. To debug with Ballerina language:
+   ```
+   ./gradlew clean build -PbalJavaDebug=<port>
+   ```
+
+7. Publish the generated artifacts to the local Ballerina central repository:
+    ```
+    ./gradlew clean build -PpublishToLocalCentral=true
     ```
 
-2. To run the unit tests:
-
-    ```shell script
-        ./gradlew clean test
-    ```
-
-3. To build the package without the tests:
-
-    ```shell script
-        ./gradlew clean build -x test
-    ```
-
-4. To debug the tests:
-
-    ```shell script
-        ./gradlew clean test -Pdebug=<port>
-    ```
+8. Publish the generated artifacts to the Ballerina central repository:
+   ```
+   ./gradlew clean build -PpublishToCentral=true
+   ```
 
 ## Contributing to Ballerina
 

--- a/ftp-ballerina/build.gradle
+++ b/ftp-ballerina/build.gradle
@@ -156,6 +156,10 @@ def disableGroups = ""
 def debugParams = ""
 def balJavaDebugParam = ""
 def testParams = ""
+def needSeparateTest = false
+def needBuildWithTest = false
+def needPublishToCentral = false
+def needPublishToLocalCentral = false
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -170,13 +174,23 @@ task initializeVariables {
     if (project.hasProperty("balJavaDebug")) {
         balJavaDebugParam = "BAL_JAVA_DEBUG=${project.findProperty("balJavaDebug")}"
     }
+    if (project.hasProperty("publishToLocalCentral") && (project.findProperty("publishToLocalCentral") == "true")) {
+        needPublishToLocalCentral = true
+    }
+    if (project.hasProperty("publishToCentral") && (project.findProperty("publishToCentral") == "true")) {
+        needPublishToCentral = true
+    }
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":${packageName}-ballerina:build") ||
                 graph.hasTask(":${packageName}-ballerina:publish") ||
                 graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
-            ballerinaTest.enabled = false
+            needSeparateTest = false
+            needBuildWithTest = true
+            if (graph.hasTask(":${packageName}-ballerina:publish")) {
+                needPublishToCentral = true
+            }
         } else {
-            ballerinaTest.enabled = true
+            needSeparateTest = true
         }
 
         if (graph.hasTask(":${packageName}-ballerina:test")) {
@@ -184,41 +198,7 @@ task initializeVariables {
         } else {
             testParams = "--skip-tests"
         }
-
-        if (graph.hasTask(":${packageName}-ballerina:publish")) {
-            ballerinaPublish.enabled = true
-        } else {
-            ballerinaPublish.enabled = false
-        }
     }
-}
-
-task ballerinaTest {
-    dependsOn(":ftp-native:build")
-    dependsOn(":ftp-test-utils:build")
-    dependsOn(unpackJballerinaTools)
-    dependsOn(unpackStdLibs)
-    dependsOn(copyStdlibs)
-    dependsOn(updateTomlFile)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
-
-    doLast {
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            environment "STDLIB_VERSION", tomlVersion
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
-            }
-        }
-    }
-}
-
-test {
-    dependsOn(ballerinaTest)
 }
 
 task ballerinaBuild {
@@ -233,82 +213,91 @@ task ballerinaBuild {
     finalizedBy(revertTomlFile)
 
     doLast {
-        // Build and populate caches
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build -c ${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build -c ${testParams} ${debugParams}"
+        if (needSeparateTest) {
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test ${testCoverageParam} ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test ${testCoverageParam} ${groupParams} ${disableGroups} ${debugParams}"
+                }
             }
-        }
-        // extract bala file to artifact cache directory
-        file("$project.projectDir/target/bala").eachFileMatch(~/.*.bala/) { balaFile ->
+        } else if (needBuildWithTest) {
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build -c ${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build -c ${testParams} ${debugParams}"
+                }
+            }
+            // extract bala file to artifact cache directory
+            file("$project.projectDir/target/bala").eachFileMatch(~/.*.bala/) { balaFile ->
+                copy {
+                    from zipTree(balaFile)
+                    into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}/${platform}")
+                }
+            }
             copy {
-                from zipTree(balaFile)
-                into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}/${platform}")
+                from file("$project.projectDir/target/cache")
+                exclude '**/*-testable.jar'
+                exclude '**/tests_cache/'
+                into file("$artifactCacheParent/cache/")
             }
-        }
 
-        copy {
-            from file("$project.projectDir/target/cache")
-            exclude '**/*-testable.jar'
-            exclude '**/tests_cache/'
-            into file("$artifactCacheParent/cache/")
-        }
-
-        copy {
-            from configurations.packingJars
-            into file("$artifactLibParent/libs")
-        }
-
-        // Doc creation and packing
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc --offline && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$distributionBinPath/bal doc --offline"
+            // Doc creation and packing
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/bal doc"
+                }
             }
-        }
-        copy {
-            from file("$project.projectDir/target/apidocs/${packageName}")
-            into file("$project.projectDir/build/docs_parent/docs/${packageName}")
+            copy {
+                from file("$project.projectDir/target/apidocs/${packageName}")
+                into file("$project.projectDir/build/docs_parent/docs/${packageName}")
+            }
+            if (needPublishToCentral) {
+                if (project.version.endsWith('-SNAPSHOT') ||
+                        project.version.matches(project.ext.timestampedVersionRegex)) {
+                    return
+                }
+                if (ballerinaCentralAccessToken != null) {
+                    println("Publishing to the ballerina central...")
+                    exec {
+                        workingDir project.projectDir
+                        environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                            commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                        } else {
+                            commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                        }
+                    }
+                } else {
+                    throw new InvalidUserDataException("Central Access Token is not present")
+                }
+            } else if (needPublishToLocalCentral) {
+                println("Publishing to the ballerina local central repository..")
+                exec {
+                    workingDir project.projectDir
+                    environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%% --repository=local"
+                    } else {
+                        commandLine 'sh', '-c', "$distributionBinPath/bal push --repository=local"
+                    }
+                }
+            }
         }
     }
 
     outputs.dir artifactCacheParent
     outputs.dir artifactBallerinaDocs
     outputs.dir artifactLibParent
-}
-
-build {
-    dependsOn(ballerinaBuild)
-}
-
-task ballerinaPublish {
-    doLast {
-        if (project.version.endsWith('-SNAPSHOT') ||
-                project.version.matches(project.ext.timestampedVersionRegex)) {
-            return
-        }
-        if (ballerinaCentralAccessToken != null) {
-            println("Publishing to the ballerina central..")
-            exec {
-                workingDir project.projectDir
-                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
-                } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
-                }
-            }
-        } else {
-            throw new InvalidUserDataException("Central Access Token is Not Present")
-        }
-    }
 }
 
 task createArtifactZip(type: Zip) {
@@ -344,9 +333,5 @@ ballerinaBuild.dependsOn updateTomlFile
 unpackJballerinaTools.dependsOn copyPackingJarsToLib
 build.dependsOn ballerinaBuild
 
-ballerinaPublish.dependsOn ":${packageName}-native:build"
-ballerinaPublish.dependsOn ballerinaBuild
-ballerinaPublish.dependsOn updateTomlFile
-ballerinaPublish.dependsOn initializeVariables
-ballerinaPublish.finalizedBy revertTomlFile
-publish.dependsOn ballerinaPublish
+publishToMavenLocal.dependsOn build
+publish.dependsOn build


### PR DESCRIPTION
## Purpose

Move ballerina build, test and publish tasks under a single task to avoid running the update and revert toml file tasks multiple times.

Part of https://github.com/ballerina-platform/ballerina-standard-library/issues/1247

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests