### PR TITLE
Fix the issue of server initialization failure when empty username and passwords are given to the basicAuth field

### DIFF
--- a/ftp-ballerina/tests/listener_endpoint_test.bal
+++ b/ftp-ballerina/tests/listener_endpoint_test.bal
@@ -71,3 +71,57 @@ public function testAddedFileCount() {
         test:assertFail("Failed to receive WatchEvent for 5 minuetes.");
     }
 }
+
+listener Listener emptyPasswordServer = new({
+    protocol: FTP,
+    host: "127.0.0.1",
+    auth: {
+        basicAuth: {
+            username: "wso2",
+            password: ""
+        }
+    },
+    port: 21212,
+    path: "/home/in",
+    pollingInterval: 2,
+    fileNamePattern: "(.*).txt"
+});
+
+@test:Config {}
+public function testServerRegisterFailureEmptyPassword() {
+    error? result = emptyPasswordServer.attach(service object {
+          function onFileChange(WatchEvent event) {}
+    }, "remote-server");
+    if (result is error) {
+        test:assertEquals(result.message(), "Failed to initialize File server connector for Service: remote-server");
+    } else {
+        test:assertFail("Empty password set to basic auth. Test should fail");
+    }
+}
+
+listener Listener emptyUsernameServer = new({
+    protocol: FTP,
+    host: "127.0.0.1",
+    auth: {
+        basicAuth: {
+            username: "",
+            password: "wso2"
+        }
+    },
+    port: 21212,
+    path: "/home/in",
+    pollingInterval: 2,
+    fileNamePattern: "(.*).txt"
+});
+
+@test:Config {}
+public function testServerRegisterFailureEmptyUsername() {
+    error? result = emptyUsernameServer.attach(service object {
+          function onFileChange(WatchEvent event) {}
+    }, "remote-server");
+    if (result is error) {
+        test:assertEquals(result.message(), "Username cannot be empty");
+    } else {
+        test:assertFail("Empty username set to basic auth. Test should fail");
+    }
+}

--- a/ftp-native/src/main/java/org/ballerinalang/stdlib/ftp/server/FtpListenerHelper.java
+++ b/ftp-native/src/main/java/org/ballerinalang/stdlib/ftp/server/FtpListenerHelper.java
@@ -47,7 +47,7 @@ public class FtpListenerHelper {
     }
 
     public static Object register(BObject ftpListener, BMap<Object, Object> serviceEndpointConfig, BObject service,
-            String name) throws BallerinaFtpException {
+            String name) {
         try {
             Map<String, String> paramMap = getServerConnectorParamMap(serviceEndpointConfig);
             RemoteFileSystemConnectorFactory fileSystemConnectorFactory = new RemoteFileSystemConnectorFactoryImpl();
@@ -61,7 +61,7 @@ public class FtpListenerHelper {
             // This is a temporary solution
             serviceEndpointConfig.addNativeData(FtpConstants.FTP_SERVER_CONNECTOR, serverConnector);
             return serverConnector;
-        } catch (RemoteFileSystemConnectorException e) {
+        } catch (RemoteFileSystemConnectorException | BallerinaFtpException e) {
             Throwable rootCause = findRootCause(e);
             String detail = (rootCause != null) ? rootCause.getMessage() : null;
             return FtpUtil.createError(e.getMessage(), detail, Error.errorType());

--- a/ftp-native/src/main/java/org/ballerinalang/stdlib/ftp/server/FtpListenerHelper.java
+++ b/ftp-native/src/main/java/org/ballerinalang/stdlib/ftp/server/FtpListenerHelper.java
@@ -33,6 +33,9 @@ import org.wso2.transport.remotefilesystem.server.connector.contract.RemoteFileS
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
+import static org.ballerinalang.stdlib.ftp.util.FtpUtil.ErrorType.Error;
 
 /**
  * Helper class for listener functions.
@@ -43,11 +46,8 @@ public class FtpListenerHelper {
         // private constructor
     }
 
-    public static RemoteFileSystemServerConnector register(BObject ftpListener,
-                                                           BMap<Object, Object> serviceEndpointConfig, BObject service,
-                                                           String name)
-            throws BallerinaFtpException {
-
+    public static Object register(BObject ftpListener, BMap<Object, Object> serviceEndpointConfig, BObject service,
+            String name) throws BallerinaFtpException {
         try {
             Map<String, String> paramMap = getServerConnectorParamMap(serviceEndpointConfig);
             RemoteFileSystemConnectorFactory fileSystemConnectorFactory = new RemoteFileSystemConnectorFactoryImpl();
@@ -62,8 +62,19 @@ public class FtpListenerHelper {
             serviceEndpointConfig.addNativeData(FtpConstants.FTP_SERVER_CONNECTOR, serverConnector);
             return serverConnector;
         } catch (RemoteFileSystemConnectorException e) {
-            throw new BallerinaFtpException("Unable to initialize the FTP listener: " + e.getMessage(), e);
+            Throwable rootCause = findRootCause(e);
+            String detail = (rootCause != null) ? rootCause.getMessage() : null;
+            return FtpUtil.createError(e.getMessage(), detail, Error.errorType());
         }
+    }
+
+    private static Throwable findRootCause(Throwable throwable) {
+        Objects.requireNonNull(throwable);
+        Throwable rootCause = throwable;
+        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+            rootCause = rootCause.getCause();
+        }
+        return rootCause;
     }
 
     private static Map<String, String> getServerConnectorParamMap(BMap serviceEndpointConfig)

--- a/ftp-native/src/main/java/org/ballerinalang/stdlib/ftp/util/FtpUtil.java
+++ b/ftp-native/src/main/java/org/ballerinalang/stdlib/ftp/util/FtpUtil.java
@@ -88,6 +88,9 @@ public class FtpUtil {
             if (basicAuth != null) {
                 username = (basicAuth.getStringValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_USERNAME)))
                         .getValue();
+                if (username.isBlank()) {
+                    throw new BallerinaFtpException("Username cannot be empty");
+                }
                 password = (basicAuth.getStringValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_PASS_KEY)))
                         .getValue();
             }


### PR DESCRIPTION
## Purpose
1. Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/99
2. Improve the returning error.
3. Return an error if the username is empty.

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
