### PR TITLE
Correctly set the `lastModifiedTimestamp` and `size` to the `FileInfo` record

### DIFF
--- a/ballerina/tests/client_endpoint_test.bal
+++ b/ballerina/tests/client_endpoint_test.bal
@@ -506,6 +506,7 @@ public function testListFiles() {
     string[] resourceNames
         = ["child_directory", "test1.txt", "complexDirectory", "test", "folder1", "test3.zip", "childDirectory",
             "test2.txt", "test3.txt"];
+    int[] fileSizes = [0, 61, 0, 0, 0, 145, 0, 16400, 12];
     FileInfo[]|Error response = clientEp->list("/home/in");
     if response is FileInfo[] {
         log:printInfo("List of files/directories: ");
@@ -513,7 +514,11 @@ public function testListFiles() {
         foreach var fileInfo in response {
             log:printInfo(fileInfo.toString());
             test:assertEquals(fileInfo.path, "/home/in/" + resourceNames[i],
-                msg = "File path is not matched during `list` operation");
+                msg = "File path is not matched during the `list` operation");
+            test:assertTrue(fileInfo.lastModifiedTimestamp > 0,
+                msg = "Last Modified Timestamp of the file is not correct during the `list` operation");
+            test:assertEquals(fileInfo.size, fileSizes[i],
+                msg = "File size is not matched during the `list` operation");
             i = i + 1;
         }
         log:printInfo("Executed `list` operation");

--- a/changelog.md
+++ b/changelog.md
@@ -22,3 +22,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  - [[#1523] Fix the issue of created zip file being corrupted](https://github.com/ballerina-platform/ballerina-standard-library/issues/1523)
  - [[#1546] Correctly handle errors of `get` method](https://github.com/ballerina-platform/ballerina-standard-library/issues/1546)
  - [[#108] Implement the `stop` functionality to the FTP connector](https://github.com/ballerina-platform/ballerina-standard-library/issues/108)
+ - [[#106] Correctly set the `lastModifiedTime` and `fileSize` to the `FileInfo` object](https://github.com/ballerina-platform/ballerina-standard-library/issues/106)

--- a/native/src/main/java/io/ballerina/stdlib/ftp/transport/message/FileInfo.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/transport/message/FileInfo.java
@@ -123,6 +123,10 @@ public class FileInfo {
         this.isHidden = fileObject.isHidden();
         this.isReadable = fileObject.isReadable();
         this.isWritable = fileObject.isWriteable();
+        this.lastModifiedTime = fileObject.getContent().getLastModifiedTime();
+        if (this.isFile) {
+            this.fileSize = fileObject.getContent().getSize();
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose

Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/106

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
