### PR TITLE
Remove `arraySize` parameter from the `get` method of the FTP Client API

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -8,6 +8,24 @@ dependencies-toml-version = "2"
 
 [[package]]
 org = "ballerina"
+name = "ftp"
+version = "2.0.0"
+transitive = false
+dependencies = [
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "lang.string"},
+	{org = "ballerina", name = "log"},
+	{org = "ballerina", name = "task"},
+	{org = "ballerina", name = "test"}
+]
+modules = [
+	{org = "ballerina", packageName = "ftp", moduleName = "ftp"}
+]
+
+[[package]]
+org = "ballerina"
 name = "io"
 version = "1.0.0"
 transitive = false
@@ -100,6 +118,7 @@ name = "log"
 version = "2.0.0"
 transitive = false
 dependencies = [
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "observe"}
 ]

--- a/ballerina/byte_stream.bal
+++ b/ballerina/byte_stream.bal
@@ -29,7 +29,6 @@ type StreamEntry record {|
 class ByteStream {
 
     private Client entity;
-    private int arraySize;
     private boolean isClosed = false;
     private string resourcePath;
     private boolean initialStreamEntryConsumed = false;
@@ -40,12 +39,11 @@ class ByteStream {
     # + entity - The `ftp:Client` which contains the byte stream
     # + resourcePath - The local path of the file/directory
     # + arraySize - The size of a byte array as an integer
-    public isolated function init(Client entity, string resourcePath, int arraySize) returns Error? {
+    public isolated function init(Client entity, string resourcePath) returns Error? {
         self.entity = entity;
-        self.arraySize = arraySize;
         self.resourcePath = resourcePath;
         record {|byte[] & readonly value;|}|Error? tempInitialStreamEntity
-            = externInitialGetStreamEntryRecord(self.entity, self.resourcePath, self.arraySize);
+            = externInitialGetStreamEntryRecord(self.entity, self.resourcePath);
         if (tempInitialStreamEntity is Error) {
             return tempInitialStreamEntity;
         } else {
@@ -59,7 +57,7 @@ class ByteStream {
     #            `()` if the stream has reached the end or else an `io:Error`
     public isolated function next() returns record {|byte[] & readonly value;|}|io:Error? {
         if (self.initialStreamEntryConsumed) {
-            return externGetStreamEntryRecord(self.entity, self.arraySize);
+            return externGetStreamEntryRecord(self.entity);
         } else {
             self.initialStreamEntryConsumed = true;
             return self.initialStreamEntry;
@@ -82,13 +80,13 @@ class ByteStream {
     }
 }
 
-isolated function externGetStreamEntryRecord(Client entity, int arraySize)
+isolated function externGetStreamEntryRecord(Client entity)
         returns record {|byte[] & readonly value;|}|io:Error? = @java:Method {
     'class: "io.ballerina.stdlib.ftp.client.FtpClient",
     name: "get"
 } external;
 
-isolated function externInitialGetStreamEntryRecord(Client entity, string path, int arraySize)
+isolated function externInitialGetStreamEntryRecord(Client entity, string path)
         returns record {|byte[] & readonly value;|}|Error? = @java:Method {
     'class: "io.ballerina.stdlib.ftp.client.FtpClient",
     name: "getFirst"

--- a/ballerina/client_endpoint.bal
+++ b/ballerina/client_endpoint.bal
@@ -41,10 +41,9 @@ public isolated client class Client {
     # ```
     #
     # + path - The resource path
-    # + arraySize - A defaultable paramerter to state the size of the byte array. Default size is 8KB
     # + return - A byte stream from which the file can be read or `ftp:Error` in case of errors
-    remote isolated function get(string path, int arraySize = 8192) returns stream<byte[] & readonly, io:Error?>|Error {
-        ByteStream|Error byteStream = new(self, path, arraySize);
+    remote isolated function get(string path) returns stream<byte[] & readonly, io:Error?>|Error {
+        ByteStream|Error byteStream = new(self, path);
         if (byteStream is ByteStream) {
             return new stream<byte[] & readonly, io:Error?>(byteStream);
         } else {

--- a/ballerina/file_event.bal
+++ b/ballerina/file_event.bal
@@ -69,6 +69,6 @@ public type FileInfo record {|
 # + addedFiles - Array of `ftp:FileInfo` that represents newly added files
 # + deletedFiles - Array of strings that contains deleted file names
 public type WatchEvent record {|
-    FileInfo[] addedFiles;
-    string[] deletedFiles;
+    FileInfo[] & readonly addedFiles;
+    string[] & readonly deletedFiles;
 |};

--- a/ballerina/file_event.bal
+++ b/ballerina/file_event.bal
@@ -69,6 +69,6 @@ public type FileInfo record {|
 # + addedFiles - Array of `ftp:FileInfo` that represents newly added files
 # + deletedFiles - Array of strings that contains deleted file names
 public type WatchEvent record {|
-    FileInfo[] & readonly addedFiles;
-    string[] & readonly deletedFiles;
+    FileInfo[] addedFiles;
+    string[] deletedFiles;
 |};

--- a/ballerina/listener_endpoint.bal
+++ b/ballerina/listener_endpoint.bal
@@ -157,7 +157,6 @@ class Job {
 # + path - Remote FTP directory location
 # + fileNamePattern - File name pattern that event need to trigger
 # + pollingInterval - Periodic time interval to check new update
-# + serverConnector - Server connector for service
 public type ListenerConfiguration record {|
     Protocol protocol = FTP;
     string host = "127.0.0.1";

--- a/ballerina/tests/client_endpoint_negative_test.bal
+++ b/ballerina/tests/client_endpoint_negative_test.bal
@@ -59,7 +59,7 @@ public function testConnectionWithInvalidConfiguration() returns error? {
     dependsOn: [testReadBlockNonFittingContent]
 }
 public function testReadNonExistingFile() returns error? {
-    stream<byte[] & readonly, io:Error?>|Error str = clientEp->get("/home/in/nonexisting.txt", 6);
+    stream<byte[] & readonly, io:Error?>|Error str = clientEp->get("/home/in/nonexisting.txt");
     if str is Error {
         test:assertEquals(str.message(), "Failed to read file: ftp://wso2:wso2123@127.0.0.1:21212/home/in/nonexisting.txt not found",
             msg = "Unexpected error during the `get` operation of an non-existing file.");

--- a/ballerina/tests/client_endpoint_test.bal
+++ b/ballerina/tests/client_endpoint_test.bal
@@ -243,7 +243,7 @@ isolated function matchStreamContent(stream<byte[] & readonly, io:Error?> binary
             break;
         } else if (binaryArray is ()) {
             break;
-        }else {
+        } else {
             tempContent = check strings:fromBytes(binaryArray.value);
             fullContent = fullContent + tempContent;
             maxLoopCount -= 1;

--- a/ballerina/tests/listener_endpoint_test.bal
+++ b/ballerina/tests/listener_endpoint_test.bal
@@ -60,7 +60,7 @@ public function testAddedFileCount() {
     while timeoutInSeconds > 0 {
         if watchEventReceived {
             log:printInfo("Added file count: " + addedFileCount.toString());
-            test:assertEquals(3, addedFileCount);
+            test:assertEquals(4, addedFileCount);
             break;
         } else {
             runtime:sleep(1);

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  - [[#1782] Throw an error when file/directory does not exist in the `isDirectory` method](https://github.com/ballerina-platform/ballerina-standard-library/issues/1782)
  - [[#1703] Revamp the logic of the FTP Listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/1703)
  - [[#1940] Remove `arraySize` parameter from the `get` method of the FTP Client API](https://github.com/ballerina-platform/ballerina-standard-library/issues/1940)
- - [[#1955] Make the access to the `WatchEvent` as `readonly` in the FTP Listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/1955)
 
 ### Fixed
  - [[#1518] Remove thrown exceptions and make then return](https://github.com/ballerina-platform/ballerina-standard-library/issues/1518)

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  - [[#1782] Throw an error when file/directory does not exist in the `isDirectory` method](https://github.com/ballerina-platform/ballerina-standard-library/issues/1782)
  - [[#1703] Revamp the logic of the FTP Listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/1703)
  - [[#1940] Remove `arraySize` parameter from the `get` method of the FTP Client API](https://github.com/ballerina-platform/ballerina-standard-library/issues/1940)
+ - [[#1955] Make the access to the `WatchEvent` as `readonly` in the FTP Listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/1955)
 
 ### Fixed
  - [[#1518] Remove thrown exceptions and make then return](https://github.com/ballerina-platform/ballerina-standard-library/issues/1518)

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  - [[#1749] Initialize `VfsClientConnector` once when the FTP Client is initialized](https://github.com/ballerina-platform/ballerina-standard-library/issues/1749)
  - [[#1782] Throw an error when file/directory does not exist in the `isDirectory` method](https://github.com/ballerina-platform/ballerina-standard-library/issues/1782)
  - [[#1703] Revamp the logic of the FTP Listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/1703)
+ - [[#1940] Remove `arraySize` parameter from the `get` method of the FTP Client API](https://github.com/ballerina-platform/ballerina-standard-library/issues/1940)
 
 ### Fixed
  - [[#1518] Remove thrown exceptions and make then return](https://github.com/ballerina-platform/ballerina-standard-library/issues/1518)

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -44,7 +44,6 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.ballerina.stdlib.ftp.util.FtpConstants.ARRAY_SIZE;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ENTITY_BYTE_STREAM;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.READ_INPUT_STREAM;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.VFS_CLIENT_CONNECTOR;
@@ -112,9 +111,8 @@ public class FtpClient {
         return null;
     }
 
-    public static Object getFirst(Environment env, BObject clientConnector, BString filePath, long arraySize) {
+    public static Object getFirst(Environment env, BObject clientConnector, BString filePath) {
         clientConnector.addNativeData(ENTITY_BYTE_STREAM, null);
-        clientConnector.addNativeData(ARRAY_SIZE, arraySize);
         Future balFuture = env.markAsync();
         FtpClientListener connectorListener = new FtpClientListener(balFuture, false,
                 remoteFileSystemBaseMessage -> FtpClientHelper.executeGetAction(remoteFileSystemBaseMessage,
@@ -125,9 +123,8 @@ public class FtpClient {
         return null;
     }
 
-    public static Object get(BObject clientConnector, long arraySize) {
-        return FtpClientHelper.generateInputStreamEntry((InputStream) clientConnector.getNativeData(READ_INPUT_STREAM),
-                arraySize);
+    public static Object get(BObject clientConnector) {
+        return FtpClientHelper.generateInputStreamEntry((InputStream) clientConnector.getNativeData(READ_INPUT_STREAM));
     }
 
     public static Object closeInputByteStream(BObject clientObject) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClientHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClientHelper.java
@@ -91,8 +91,7 @@ class FtpClientHelper {
                 Channel channel = new FtpChannel(byteChannel);
                 InputStream inputStream = channel.getInputStream();
                 clientConnector.addNativeData(READ_INPUT_STREAM, inputStream);
-                long arraySize = (long) clientConnector.getNativeData(ARRAY_SIZE);
-                BMap<BString, Object> streamEntry = generateInputStreamEntry(inputStream, arraySize);
+                BMap<BString, Object> streamEntry = generateInputStreamEntry(inputStream);
                 clientConnector.addNativeData(ENTITY_BYTE_STREAM, streamEntry);
                 balFuture.complete(streamEntry);
             }
@@ -102,11 +101,10 @@ class FtpClientHelper {
         return true;
     }
 
-    public static BMap<BString, Object> generateInputStreamEntry(InputStream inputStream, long arraySize) {
+    public static BMap<BString, Object> generateInputStreamEntry(InputStream inputStream) {
         BMap<BString, Object> streamEntry = ValueCreator.createRecordValue(getFtpPackage(), STREAM_ENTRY_RECORD);
-        int arraySizeInt = (int) arraySize;
         try {
-            byte[] buffer = new byte[arraySizeInt];
+            byte[] buffer = new byte[ARRAY_SIZE];
             int readNumber = inputStream.read(buffer);
             if (readNumber == -1) {
                 inputStream.close();
@@ -114,7 +112,7 @@ class FtpClientHelper {
                 return null;
             }
             byte[] returnArray;
-            if (readNumber < arraySizeInt) {
+            if (readNumber < ARRAY_SIZE) {
                 returnArray = Arrays.copyOfRange(buffer, 0, readNumber);
             } else {
                 returnArray = buffer;

--- a/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpConstants.java
@@ -48,7 +48,7 @@ public class FtpConstants {
     public static final String FTP_MODULE_NAME = "ftp";
     public static final String ENTITY_BYTE_STREAM = "entity_byte_stream";
     public static final String READ_INPUT_STREAM = "readInputStream";
-    public static final String ARRAY_SIZE = "arraySize";
+    public static final int ARRAY_SIZE = 8192;
     public static final String BYTE_STREAM_NEXT_FUNC = "next";
     public static final String BYTE_STREAM_CLOSE_FUNC = "close";
     public static final String STREAM_ENTRY_RECORD = "StreamEntry";

--- a/test-utils/src/main/java/io/ballerina/stdlib/ftp/testutils/mockServerUtils/MockFtpServer.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/ftp/testutils/mockServerUtils/MockFtpServer.java
@@ -140,14 +140,19 @@ public class MockFtpServer {
         ftpServer = new FakeFtpServer();
         ftpServer.setServerControlPort(port);
         String rootFolder = "/home/in";
-        String content = "File content";
+        String content1 = "File content";
+        String content2 = "";
+        for (int i = 0; i < 1000; i++) {
+            content2 += "123456789";
+        }
 
         ftpServer.addUserAccount(new UserAccount(username, password, rootFolder));
         FileSystem fileSystem = new UnixFakeFileSystem();
         fileSystem.add(new DirectoryEntry(rootFolder));
-        fileSystem.add(new FileEntry("/home/in/test1.txt", content));
-        fileSystem.add(new FileEntry("/home/in/test2.txt", content));
-        fileSystem.add(new FileEntry("/home/in/test3.txt", content));
+        fileSystem.add(new FileEntry("/home/in/test1.txt", content1));
+        fileSystem.add(new FileEntry("/home/in/test2.txt", content1));
+        fileSystem.add(new FileEntry("/home/in/test3.txt", content1));
+        fileSystem.add(new FileEntry("/home/in/test4.txt", content2));
         fileSystem.add(new DirectoryEntry("/home/in/folder1"));
         fileSystem.add(new DirectoryEntry("/home/in/folder1/subfolder1"));
         fileSystem.add(new DirectoryEntry("/home/in/childDirectory"));


### PR DESCRIPTION
## Purpose

1. Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/1940
2. Improve `rmdir` test cases

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
