### PR TITLE
Make the `WatchEvent` as `readonly`, and update APIs including the compression API

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '/github/workspace/ballerina'
+          skip-dirs: 'build'
           format: 'table'
           exit-code: '1'
       - name: Publish artifact

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '/github/workspace/ballerina'
+          skip-dirs: 'build'
           format: 'table'
           exit-code: '1'
       - name: Set version env variable

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -26,5 +26,6 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '/github/workspace/ballerina'
+          skip-dirs: 'build'
           format: 'table'
           exit-code: '1'

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,6 @@ dependencies-toml-version = "2"
 org = "ballerina"
 name = "ftp"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -28,7 +27,6 @@ modules = [
 org = "ballerina"
 name = "io"
 version = "1.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -41,7 +39,6 @@ modules = [
 org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
-transitive = false
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
 ]
@@ -51,7 +48,6 @@ org = "ballerina"
 name = "lang.__internal"
 version = "0.0.0"
 scope = "testOnly"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -62,7 +58,6 @@ org = "ballerina"
 name = "lang.array"
 version = "0.0.0"
 scope = "testOnly"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.__internal"}
@@ -73,14 +68,12 @@ org = "ballerina"
 name = "lang.object"
 version = "0.0.0"
 scope = "testOnly"
-transitive = true
 
 [[package]]
 org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
 scope = "testOnly"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.array"},
@@ -95,7 +88,6 @@ org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
 scope = "testOnly"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -107,7 +99,6 @@ modules = [
 org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -116,7 +107,6 @@ dependencies = [
 org = "ballerina"
 name = "log"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -130,7 +120,6 @@ modules = [
 org = "ballerina"
 name = "observe"
 version = "0.9.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -139,7 +128,6 @@ dependencies = [
 org = "ballerina"
 name = "task"
 version = "2.0.0"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -153,7 +141,6 @@ org = "ballerina"
 name = "test"
 version = "0.0.0"
 scope = "testOnly"
-transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -165,7 +152,6 @@ modules = [
 org = "ballerina"
 name = "time"
 version = "2.0.0"
-transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -62,7 +62,7 @@ The following code compresses and uploads a file to a remote FTP server.
 stream<io:Block, io:Error?> fileByteStream
     = check io:fileReadBlocksAsStream(putFilePath, <Block size>);
 ftp:Error? compressedPutResponse = ftpClient->put("<Resource path>",
-    fileByteStream, true);
+    fileByteStream, compressionType=ZIP);
 ```
 
 ##### Getting the Size of a Remote File
@@ -78,7 +78,7 @@ int|ftp:Error sizeResponse = ftpClient->size("<The resource path>");
 The following code reads the content of a file in a remote FTP server.
 
 ```ballerina
-stream<byte[], io:Error?>|Error str = clientEP -> get("<The file path>", <Block size>);
+stream<byte[], io:Error?>|Error str = clientEP -> get("<The file path>");
 if (str is stream<byte[], io:Error?>) {
     record {|byte[] value;|}|io:Error? arr1 = str.next();
     if (arr1 is record {|byte[] value;|}) {
@@ -153,8 +153,8 @@ listener ftp:Listener remoteServer = check new({
     fileNamePattern: "<File name pattern>"
 });
 
-service ftpServerConnector on remoteServer {
-    resource function onFileChange(ftp:WatchEvent fileEvent) {
+service on remoteServer {
+    remote function onFileChange(ftp:WatchEvent fileEvent) {
 
         foreach ftp:FileInfo addedFile in fileEvent.addedFiles {
             log:print("Added file path: " + addedFile.path);

--- a/ballerina/client_endpoint.bal
+++ b/ballerina/client_endpoint.bal
@@ -73,12 +73,18 @@ public isolated client class Client {
     #
     # + path - The resource path
     # + content - Content to be written to the file in server
-    # + compressInput - True if file should be compressed before uploading
+    # + compressionType - Type of the compression to be used, if
+    #                     the file should be compressed before
+    #                     uploading
     # + return - `()` or else an `ftp:Error` if failed to establish
     #            the communication with the FTP server
     remote isolated function put(string path, stream<byte[] & readonly, io:Error?>
-            |string|xml|json content, boolean compressInput=false) returns Error? {
-        return put(self, getInputContent(path, content, compressInput));
+            |string|xml|json content, Compression compressionType=NONE) returns Error? {
+        boolean compress = false;
+        if compressionType != NONE {
+            compress = true;
+        }
+        return put(self, getInputContent(path, content, compress));
     }
 
     # Creates a new direcotry in an FTP server.
@@ -166,6 +172,15 @@ public isolated client class Client {
     remote isolated function delete(string path) returns Error? {
         return delete(self, path);
     }
+}
+
+# Compression type.
+#
+# + ZIP - Zip compression
+# + NONE - No compression used
+public enum Compression {
+    ZIP,
+    NONE
 }
 
 # Configuration for FTP client.

--- a/ballerina/file_event.bal
+++ b/ballerina/file_event.bal
@@ -68,7 +68,7 @@ public type FileInfo record {|
 #
 # + addedFiles - Array of `ftp:FileInfo` that represents newly added files
 # + deletedFiles - Array of strings that contains deleted file names
-public type WatchEvent record {|
+public type WatchEvent readonly & record {|
     FileInfo[] addedFiles;
     string[] deletedFiles;
 |};

--- a/ballerina/listener_endpoint.bal
+++ b/ballerina/listener_endpoint.bal
@@ -24,7 +24,6 @@ public class Listener {
     private handle EMPTY_JAVA_STRING = java:fromString("");
     private ListenerConfiguration config = {};
     private task:JobId? jobId = ();
-    private handle? serverConnector = ();
 
     # Gets invoked during object initialization.
     #

--- a/ballerina/tests/client_endpoint_test.bal
+++ b/ballerina/tests/client_endpoint_test.bal
@@ -184,7 +184,7 @@ public function testPutFileContent() returns error? {
 public function testPutCompressedFileContent() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
 
-    Error? response = clientEp->put("/home/in/test3.txt", bStream, compressInput=true);
+    Error? response = clientEp->put("/home/in/test3.txt", bStream, compressionType=ZIP);
     if response is Error {
         test:assertFail(msg = "Found unexpected response type from compressed `put` operation" + response.message());
     }

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
  - [[#1782] Throw an error when file/directory does not exist in the `isDirectory` method](https://github.com/ballerina-platform/ballerina-standard-library/issues/1782)
  - [[#1703] Revamp the logic of the FTP Listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/1703)
  - [[#1940] Remove `arraySize` parameter from the `get` method of the FTP Client API](https://github.com/ballerina-platform/ballerina-standard-library/issues/1940)
+ - [[#1957] Change `boolean` typed `compressInput` parameter of the `put` method of FTP Client to an `enum` type with the name, `compressionType`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1957)
+ - [[#1955] Make the access to the `WatchEvent` as `readonly` in the FTP Listener](https://github.com/ballerina-platform/ballerina-standard-library/issues/1955)
 
 ### Fixed
  - [[#1518] Remove thrown exceptions and make then return](https://github.com/ballerina-platform/ballerina-standard-library/issues/1518)

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,8 @@ jclSlf4jVersion=1.7.21
 
 ballerinaGradlePluginVersion=0.11.0
 
-ballerinaLangVersion=2.0.0-beta.3-20210924-221600-d3a6fd96
-stdlibTaskVersion=2.0.0-20210925-191100-3246e5f
-stdlibLogVersion=2.0.0-20210925-191000-c175cb3
-stdlibIoVersion=1.0.0-20210924-082000-e70b47b
-stdlibTimeVersion=2.0.0-20210924-082000-8646324
+ballerinaLangVersion=2.0.0-beta.3-20210928-131700-4ade688e
+stdlibTaskVersion=2.0.0-20210928-151000-97f42db
+stdlibLogVersion=2.0.0-20210928-151200-403bfd8
+stdlibIoVersion=1.0.0-20210928-145300-8fa070c
+stdlibTimeVersion=2.0.0-20210928-145300-c70d0e7

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -181,13 +181,9 @@ public class FtpClient {
             if (compressInput) {
                 compressedStream = FtpUtil.compress(stream, (inputContent.getStringValue(StringUtils.fromString(
                         FtpConstants.INPUT_CONTENT_FILE_PATH_KEY))).getValue());
-                if (compressedStream != null) {
-                    message = FtpClientHelper.getCompressedMessage(clientConnector, (inputContent.getStringValue(
-                            StringUtils.fromString(FtpConstants.INPUT_CONTENT_FILE_PATH_KEY))).getValue(),
-                            propertyMap, compressedStream);
-                } else {
-                    return FtpUtil.createError("Error while compressing a file", Error.errorType());
-                }
+                message = FtpClientHelper.getCompressedMessage(clientConnector, (inputContent.getStringValue(
+                        StringUtils.fromString(FtpConstants.INPUT_CONTENT_FILE_PATH_KEY))).getValue(),
+                        propertyMap, compressedStream);
             } else {
                 try {
                     message = FtpClientHelper.getUncompressedMessage(clientConnector, (inputContent.getStringValue(
@@ -213,9 +209,7 @@ public class FtpClient {
         }
         connector.send(message, FtpAction.PUT, filePath, null);
         try {
-            if (stream != null) {
-                stream.close();
-            }
+            stream.close();
             if (compressedStream != null) {
                 compressedStream.close();
             }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClientHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClientHelper.java
@@ -267,7 +267,7 @@ class FtpClientHelper {
 
     private static void callStreamNext(Environment env, BObject entity, BufferHolder bufferHolder,
                                        BObject iteratorObj, CountDownLatch latch) {
-        env.getRuntime().invokeMethodAsync(iteratorObj, BYTE_STREAM_NEXT_FUNC, null, null, new Callback() {
+        env.getRuntime().invokeMethodAsyncConcurrently(iteratorObj, BYTE_STREAM_NEXT_FUNC, null, null, new Callback() {
             @Override
             public void notifySuccess(Object result) {
                 if (result == bufferHolder.getTerminalType()) {
@@ -287,12 +287,12 @@ class FtpClientHelper {
             public void notifyFailure(BError bError) {
                 latch.countDown();
             }
-        });
+        }, null, null, null, true);
     }
 
     private static void callStreamClose(Environment env, BObject entity, BufferHolder bufferHolder,
                                        BObject iteratorObj, CountDownLatch latch) {
-        env.getRuntime().invokeMethodAsync(iteratorObj, BYTE_STREAM_CLOSE_FUNC, null, null, new Callback() {
+        env.getRuntime().invokeMethodAsyncConcurrently(iteratorObj, BYTE_STREAM_CLOSE_FUNC, null, null, new Callback() {
             @Override
             public void notifySuccess(Object result) {
                 this.terminateStream();
@@ -308,7 +308,7 @@ class FtpClientHelper {
                 bufferHolder.setTerminal(true);
                 latch.countDown();
             }
-        });
+        }, null, null, null, true);
     }
 
     static RemoteFileSystemMessage getUncompressedMessage(BObject clientConnector, String filePath,


### PR DESCRIPTION
## Purpose
1. Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/1955
2. Resolves https://github.com/ballerina-platform/ballerina-standard-library/issues/1957
3. Migrate the deprecated API, `invokeMethodAsync` to the `invokeMethodAsyncConcurrently` of the runtime
4. Clean unnecessary code

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
