### PR TITLE
Fix intermittent tests initialization failure

### DIFF
--- a/ballerina/tests/client_endpoint_negative_test.bal
+++ b/ballerina/tests/client_endpoint_negative_test.bal
@@ -59,7 +59,7 @@ public function testConnectionWithInvalidConfiguration() returns error? {
     dependsOn: [testReadBlockNonFittingContent]
 }
 public function testReadNonExistingFile() returns error? {
-    stream<byte[] & readonly, io:Error?>|Error str = clientEp->get("/home/in/nonexisting.txt");
+    stream<byte[] & readonly, io:Error?>|Error str = (<Client>clientEp)->get("/home/in/nonexisting.txt");
     if str is Error {
         test:assertEquals(str.message(), "Failed to read file: ftp://wso2:wso2123@127.0.0.1:21212/home/in/nonexisting.txt not found",
             msg = "Unexpected error during the `get` operation of an non-existing file.");
@@ -73,7 +73,7 @@ public function testReadNonExistingFile() returns error? {
 }
 public function testAppendContentToNonExistingFile() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(appendFilePath, 7);
-    Error? receivedError = clientEp->append("/../invalidFile", bStream);
+    Error? receivedError = (<Client>clientEp)->append("/../invalidFile", bStream);
     if receivedError is Error {
         test:assertEquals(receivedError.message(), "Invalid relative file name.",
             msg = "Unexpected error during the `append` operation of an invalid file.");
@@ -87,7 +87,7 @@ public function testAppendContentToNonExistingFile() returns error? {
 }
 public function testPutFileContentAtInvalidFileLocation() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    Error? receivedError = clientEp->put("/../InvalidFile", bStream);
+    Error? receivedError = (<Client>clientEp)->put("/../InvalidFile", bStream);
     if receivedError is Error {
         test:assertEquals(receivedError.message(), "Invalid relative file name.",
             msg = "Unexpected error during the `put` operation of an invalid file.");
@@ -100,7 +100,7 @@ public function testPutFileContentAtInvalidFileLocation() returns error? {
     dependsOn: [testIsDirectory]
 }
 public function testIsDirectoryWithNonExistingDirectory() {
-    boolean|Error receivedError = clientEp->isDirectory("/home/in/nonexisting");
+    boolean|Error receivedError = (<Client>clientEp)->isDirectory("/home/in/nonexisting");
     if receivedError is Error {
         test:assertEquals(receivedError.message(), "/home/in/nonexisting does not exists to check if it is a directory.",
             msg = "Unexpected error during the `isDirectory` operation of an non-existing directory. " + receivedError.message());
@@ -113,7 +113,7 @@ public function testIsDirectoryWithNonExistingDirectory() {
     dependsOn: [testCreateDirectory]
 }
 public function testCreateDirectoryAtInvalidLocation() {
-    Error? receivedError = clientEp->mkdir("/../InvalidDirectory");
+    Error? receivedError = (<Client>clientEp)->mkdir("/../InvalidDirectory");
     if receivedError is Error {
         test:assertEquals(receivedError.message(), "Invalid relative file name.",
             msg = "Unexpected error during the `mkdir` operation of an non-existing directory. " + receivedError.message());
@@ -128,7 +128,7 @@ public function testCreateDirectoryAtInvalidLocation() {
 public function testRenameNonExistingDirectory() {
     string existingName = "/nonExistingDirectory";
     string newName = "/home/in/differentDirectory";
-    Error? receivedError = clientEp->rename(existingName, newName);
+    Error? receivedError = (<Client>clientEp)->rename(existingName, newName);
 
     if receivedError is Error {
         test:assertTrue(receivedError.message().startsWith("Failed to rename file: "),
@@ -142,7 +142,7 @@ public function testRenameNonExistingDirectory() {
     dependsOn: [testGetFileSize]
 }
 public function testGetFileSizeFromNonExistingFile() {
-    int|Error receivedError = clientEp->size("/nonExistingFile");
+    int|Error receivedError = (<Client>clientEp)->size("/nonExistingFile");
     if receivedError is Error {
         test:assertTrue(receivedError.message().startsWith("Could not determine the size of "),
             msg = "Unexpected error during the `size` operation of an non-existing file. " + receivedError.message());
@@ -155,7 +155,7 @@ public function testGetFileSizeFromNonExistingFile() {
     dependsOn: [testListFiles]
 }
 public function testListFilesFromNonExistingDirectory() {
-    FileInfo[]|Error receivedError = clientEp->list("/nonExistingDirectory");
+    FileInfo[]|Error receivedError = (<Client>clientEp)->list("/nonExistingDirectory");
     if receivedError is Error {
         test:assertTrue(receivedError.message().startsWith("Could not list the contents of "),
             msg = "Unexpected error during the `list` operation of an non-existing directory. " + receivedError.message());
@@ -168,7 +168,7 @@ public function testListFilesFromNonExistingDirectory() {
     dependsOn: [testDeleteFile]
 }
 public function testDeleteFileAtNonExistingLocation() returns error? {
-    Error? receivedError = clientEp->delete("/nonExistingFile");
+    Error? receivedError = (<Client>clientEp)->delete("/nonExistingFile");
     if receivedError is Error {
         test:assertTrue(receivedError.message().startsWith("Failed to delete file: "),
             msg = "Unexpected error during the `delete` operation of an non-existing file. " + receivedError.message());
@@ -181,7 +181,7 @@ public function testDeleteFileAtNonExistingLocation() returns error? {
     dependsOn: [testRemoveDirectory]
 }
 public function testRemoveDirectoryWithWrongUrl() {
-    Error? receivedError = clientEp->rmdir("/nonExistingDirectory");
+    Error? receivedError = (<Client>clientEp)->rmdir("/nonExistingDirectory");
     if receivedError is Error {
         test:assertTrue(receivedError.message().startsWith("Failed to delete directory: "),
             msg = "Unexpected error during the `rmdir` operation of a non-existing directory. " + receivedError.message());

--- a/ballerina/tests/client_endpoint_test.bal
+++ b/ballerina/tests/client_endpoint_test.bal
@@ -571,7 +571,7 @@ function testGenericRmdir(string path) returns error? {
 }
 
 @test:AfterSuite {}
-public function stopServer() returns error? {
+public function cleanTestEnvironment() returns error? {
     check (<Listener>callerListener).gracefulStop();
     check (<Listener>remoteServerListener).gracefulStop();
     check (<Listener>anonymousRemoteServerListener).gracefulStop();

--- a/ballerina/tests/secure_client_endpoint_test.bal
+++ b/ballerina/tests/secure_client_endpoint_test.bal
@@ -22,7 +22,7 @@ import ballerina/log;
     dependsOn: [testRemoveDirectory]
 }
 public function testSecureGetFileContent() returns error? {
-    stream<byte[] & readonly, io:Error?>|Error str = sftpClientEp->get("/file2.txt");
+    stream<byte[] & readonly, io:Error?>|Error str = (<Client>sftpClientEp)->get("/file2.txt");
     if str is stream<byte[] & readonly, io:Error?> {
         test:assertTrue(check matchStreamContent(str, "Put content"),
             msg = "Found unexpected content from secure `get` operation");
@@ -266,13 +266,13 @@ public function testSecureConnectWithInvalidKeyPath() returns error? {
 public function testSecurePutFileContent() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
 
-    Error? response = sftpClientEp->put("/tempFile1.txt", bStream);
+    Error? response = (<Client>sftpClientEp)->put("/tempFile1.txt", bStream);
     if response is Error {
         test:assertFail(msg = "Error in secure `put` operation" + response.message());
     }
     log:printInfo("Executed secure `put` operation");
 
-    stream<byte[] & readonly, io:Error?>|Error str = sftpClientEp->get("/tempFile1.txt");
+    stream<byte[] & readonly, io:Error?>|Error str = (<Client>sftpClientEp)->get("/tempFile1.txt");
     if str is stream<byte[] & readonly, io:Error?> {
         test:assertTrue(check matchStreamContent(str, "Put content"),
             msg = "Found unexpected content from secure `get` operation after `put` operation");
@@ -289,13 +289,13 @@ public function testSecurePutFileContent() returns error? {
     dependsOn: [testSecurePutFileContent]
 }
 public function testSecureDeleteFileContent() returns error? {
-    Error? response = sftpClientEp->delete("/tempFile1.txt");
+    Error? response = (<Client>sftpClientEp)->delete("/tempFile1.txt");
     if response is Error {
         test:assertFail(msg = "Error in secure `delete` operation" + response.message());
     }
     log:printInfo("Executed secure `delete` operation");
 
-    stream<byte[] & readonly, io:Error?>|Error str = sftpClientEp->get("/tempFile1.txt");
+    stream<byte[] & readonly, io:Error?>|Error str = (<Client>sftpClientEp)->get("/tempFile1.txt");
     if str is stream<byte[] & readonly, io:Error?> {
         test:assertFalse(check matchStreamContent(str, "Put content"),
             msg = "File was not deleted with secure `delete` operation");

--- a/ballerina/tests/secure_listener_endpoint_test.bal
+++ b/ballerina/tests/secure_listener_endpoint_test.bal
@@ -22,7 +22,7 @@ int secureAddedFileCount = 0;
 int secureDeletedFileCount = 0;
 boolean secureWatchEventReceived = false;
 
-listener Listener secureRemoteServer = check new ({
+ListenerConfiguration secureRemoteServerConfig = {
     protocol: SFTP,
     host: "127.0.0.1",
     auth: {
@@ -38,9 +38,9 @@ listener Listener secureRemoteServer = check new ({
     port: 21213,
     pollingInterval: 2,
     fileNamePattern: "(.*).txt"
-});
+};
 
-service "ftpServerConnector" on secureRemoteServer {
+Service secureRemoteServerService = service object {
     remote function onFileChange(WatchEvent & readonly event) {
         secureAddedFileCount = event.addedFiles.length();
         secureDeletedFileCount = event.deletedFiles.length();
@@ -53,10 +53,9 @@ service "ftpServerConnector" on secureRemoteServer {
             log:printInfo("Deleted file path: " + deletedFile);
         }
     }
-}
+};
 
-@test:Config {
-}
+@test:Config {}
 public function testSecureAddedFileCount() {
     int timeoutInSeconds = 300;
     // Test fails in 5 minutes if failed to receive watchEvent

--- a/ballerina/tests/secure_listener_endpoint_with_caller_test.bal
+++ b/ballerina/tests/secure_listener_endpoint_with_caller_test.bal
@@ -23,25 +23,25 @@ boolean fileGetContentCorrect = false;
 int fileSize = 0;
 boolean isDir = false;
 
-listener Listener callerListener = check new ({
+ListenerConfiguration callerListenerConfig = {
     protocol: SFTP,
     host: "127.0.0.1",
     auth: {
         credentials: {
-            username: "wso2",
-            password: "wso2123"
+           username: "wso2",
+           password: "wso2123"
         },
         privateKey: {
-            path: "tests/resources/sftp.private.key",
-            password: "changeit"
+           path: "tests/resources/sftp.private.key",
+           password: "changeit"
         }
     },
     port: 21213,
     pollingInterval: 2,
     fileNamePattern: "(.*).caller"
-});
+};
 
-service "callerService" on callerListener {
+Service callerService = service object {
     string addedFilepath = "";
 
     remote function onFileChange(WatchEvent & readonly event, Caller caller) returns error? {
@@ -73,48 +73,48 @@ service "callerService" on callerListener {
             isDir = check caller->isDirectory("/callerDir");
         }
     }
-}
+};
 
 @test:Config {}
 public function testFilePutWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/put.caller", bStream);
+    check (<Client>sftpClientEp)->put("/put.caller", bStream);
     runtime:sleep(3);
-    stream<byte[] & readonly, io:Error?> str = check sftpClientEp->get("/put2.caller");
+    stream<byte[] & readonly, io:Error?> str = check (<Client>sftpClientEp)->get("/put2.caller");
     test:assertTrue(check matchStreamContent(str, "Put content"));
     check str.close();
-    check sftpClientEp->delete("/put.caller");
-    check sftpClientEp->delete("/put2.caller");
+    check (<Client>sftpClientEp)->delete("/put.caller");
+    check (<Client>sftpClientEp)->delete("/put2.caller");
 }
 
 @test:Config {}
 public function testFileAppendWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/append.caller", bStream);
+    check (<Client>sftpClientEp)->put("/append.caller", bStream);
     runtime:sleep(3);
-    stream<byte[] & readonly, io:Error?> str = check sftpClientEp->get("/append.caller");
+    stream<byte[] & readonly, io:Error?> str = check (<Client>sftpClientEp)->get("/append.caller");
     test:assertTrue(check matchStreamContent(str, "Put contentAppend content"));
     check str.close();
-    check sftpClientEp->delete("/append.caller");
+    check (<Client>sftpClientEp)->delete("/append.caller");
 }
 
 @test:Config {}
 public function testFileRenameWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/rename.caller", bStream);
+    check (<Client>sftpClientEp)->put("/rename.caller", bStream);
     runtime:sleep(3);
-    stream<byte[] & readonly, io:Error?> str = check sftpClientEp->get("/rename2.caller");
+    stream<byte[] & readonly, io:Error?> str = check (<Client>sftpClientEp)->get("/rename2.caller");
     test:assertTrue(check matchStreamContent(str, "Put content"));
     check str.close();
-    check sftpClientEp->delete("/rename2.caller");
+    check (<Client>sftpClientEp)->delete("/rename2.caller");
 }
 
 @test:Config {}
 public function testFileDeleteWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/delete.caller", bStream);
+    check (<Client>sftpClientEp)->put("/delete.caller", bStream);
     runtime:sleep(3);
-    stream<byte[] & readonly, io:Error?>|Error result = sftpClientEp->get("/delete.caller");
+    stream<byte[] & readonly, io:Error?>|Error result = (<Client>sftpClientEp)->get("/delete.caller");
     if result is Error {
         test:assertTrue(result.message().endsWith("delete.caller not found"));
     } else {
@@ -125,29 +125,29 @@ public function testFileDeleteWithCaller() returns error? {
 @test:Config {}
 public function testFileListWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/list.caller", bStream);
+    check (<Client>sftpClientEp)->put("/list.caller", bStream);
     runtime:sleep(3);
     test:assertEquals(fileList[0].path, "/list.caller");
-    check sftpClientEp->delete("/list.caller");
+    check (<Client>sftpClientEp)->delete("/list.caller");
 }
 
 @test:Config {}
 public function testFileGetWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/get.caller", bStream);
+    check (<Client>sftpClientEp)->put("/get.caller", bStream);
     runtime:sleep(3);
     test:assertTrue(fileGetContentCorrect);
-    check sftpClientEp->delete("/get.caller");
+    check (<Client>sftpClientEp)->delete("/get.caller");
 }
 
 @test:Config {}
 public function testMkDirWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/mkdir.caller", bStream);
+    check (<Client>sftpClientEp)->put("/mkdir.caller", bStream);
     runtime:sleep(3);
-    boolean isDir = check sftpClientEp->isDirectory("/callerDir");
+    boolean isDir = check (<Client>sftpClientEp)->isDirectory("/callerDir");
     test:assertTrue(isDir);
-    check sftpClientEp->delete("/mkdir.caller");
+    check (<Client>sftpClientEp)->delete("/mkdir.caller");
 }
 
 @test:Config {
@@ -155,10 +155,10 @@ public function testMkDirWithCaller() returns error? {
 }
 public function testIsDirectoryWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/isdirectory.caller", bStream);
+    check (<Client>sftpClientEp)->put("/isdirectory.caller", bStream);
     runtime:sleep(3);
     test:assertTrue(isDir);
-    check sftpClientEp->delete("/isdirectory.caller");
+    check (<Client>sftpClientEp)->delete("/isdirectory.caller");
 }
 
 @test:Config {
@@ -166,22 +166,22 @@ public function testIsDirectoryWithCaller() returns error? {
 }
 public function testRmDirWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/rmdir.caller", bStream);
+    check (<Client>sftpClientEp)->put("/rmdir.caller", bStream);
     runtime:sleep(3);
-    boolean|Error result = sftpClientEp->isDirectory("/callerDir");
+    boolean|Error result = (<Client>sftpClientEp)->isDirectory("/callerDir");
     if result is Error {
         test:assertEquals(result.message(), "/callerDir does not exists to check if it is a directory.");
     } else {
         test:assertFail("Expected an error");
     }
-    check sftpClientEp->delete("/rmdir.caller");
+    check (<Client>sftpClientEp)->delete("/rmdir.caller");
 }
 
 @test:Config {}
 public function testFileSizeWithCaller() returns error? {
     stream<io:Block, io:Error?> bStream = check io:fileReadBlocksAsStream(putFilePath, 5);
-    check sftpClientEp->put("/size.caller", bStream);
+    check (<Client>sftpClientEp)->put("/size.caller", bStream);
     runtime:sleep(3);
     test:assertEquals(fileSize, 11);
-    check sftpClientEp->delete("/size.caller");
+    check (<Client>sftpClientEp)->delete("/size.caller");
 }


### PR DESCRIPTION
## Purpose
$subject
This PR will add all module level client/listener initialization inside `BeforeSuite` function so that ftp servers are started before the clients initialize.
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2843
## Examples

## Checklist
- [x] Linked to an issue
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
- [ ] ~Updated the spec~
