### PR TITLE
Exit service after a panic happens inside the `onFileChange` method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id "com.github.spotbugs" version "4.0.5"
+    id "com.github.spotbugs" version "4.2.3"
     id "com.github.johnrengelman.shadow" version "5.2.0"
     id "de.undercouch.download" version "4.0.4"
     id "net.researchgate.release" version "2.8.0"

--- a/changelog.md
+++ b/changelog.md
@@ -6,23 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Changed
+- [Exit the service when a panic occurs inside the service method](https://github.com/ballerina-platform/ballerina-standard-library/issues/4241)
+
+## [2.5.0] - 2022-11-29
+
+### Changed
 - [API docs updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
+- [Stopped Java client logs from appearing in the console](https://github.com/ballerina-platform/module-ballerina-ftp/pull/824)
+
+## [2.4.1] - 2022-12-08
+
+### Changed
+- [Updated `commons-net` version to `3.9.0`](https://github.com/ballerina-platform/ballerina-standard-library/issues/3841)
 
 ## [2.3.0] - 2022-05-30
 
 ### Added
- - [[#2525] Introduced `ftp:Caller` API and added as an optional parameter in `onFileChange` method](https://github.com/ballerina-platform/ballerina-standard-library/issues/2525)
- - [[#1514] Added compiler plugin validation support for `ftp:Service`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1514)
- - [[#2704] Added code snippet generation for `ftp:Service`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2704)
+- [[#2525] Introduced `ftp:Caller` API and added as an optional parameter in `onFileChange` method](https://github.com/ballerina-platform/ballerina-standard-library/issues/2525)
+- [[#1514] Added compiler plugin validation support for `ftp:Service`](https://github.com/ballerina-platform/ballerina-standard-library/issues/1514)
+- [[#2704] Added code snippet generation for `ftp:Service`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2704)
 
 ## [2.2.0] - 2022-01-28
 
 ### Changed
  - [[#2741] Remove `readonly` type of `ftp:WatchEvent` and support both `ftp:WatchEvent & readonly` and `ftp:WatchEvent` in `onFileChange` method](https://github.com/ballerina-platform/ballerina-standard-library/issues/2741)
-
-## [2.2.0] - 2022-01-28
-
-### Changed
  - [[#2549] Make `path` field to root and `fileNamePattern` field optional in `ftp:ListenerConfiguration`](https://github.com/ballerina-platform/ballerina-standard-library/issues/2549)
 
 ## [2.0.1] - 2021-11-20

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
@@ -126,12 +126,16 @@ public class FtpListener implements RemoteFileSystemListener {
     private void invokeMethodAsync(BObject service, Object ...args) {
         Callback callback = new Callback() {
             @Override
-            public void notifySuccess(Object o) {
+            public void notifySuccess(Object result) {
+                if (result instanceof BError) {
+                    ((BError) result).printStackTrace();
+                }
             }
             
             @Override
             public void notifyFailure(BError error) {
                 error.printStackTrace();
+                System.exit(1);
             }
         };
         ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(service.getType());


### PR DESCRIPTION
## Purpose
$subject
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/4241
Tested the scenarios locally since we cannot add tests to this as `System.exit` will exit the complete test suite in the runtime.

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility
