### PR TITLE
Enable central verbose for the publish release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,3 +14,5 @@ jobs:
     with:
       package-name: ftp
       package-org: ballerina
+    env:
+      CENTRAL_VERBOSE_ENABLED: true


### PR DESCRIPTION
## Purpose

- Enable central verbose for the publish release workflow

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
