### PR TITLE
Update min distribution to 2201.13.0

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "ftp"
-version = "2.17.1"
+version = "2.18.0"
 authors = ["Ballerina"]
 keywords = ["FTP", "SFTP", "remote file", "file transfer", "client", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-ftp"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.13.0"
 
 [platform.java21]
 graalvmCompatible = true
@@ -45,8 +45,8 @@ path = "./lib/commons-lang3-3.18.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ftp-native"
-version = "2.17.1"
-path = "../native/build/libs/ftp-native-2.17.1.jar"
+version = "2.18.0"
+path = "../native/build/libs/ftp-native-2.18.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "ftp-compiler-plugin"
 class = "io.ballerina.stdlib.ftp.plugin.FtpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.17.1.jar"
+path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.18.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.13.2"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.10.1"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.1"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.2"
 
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -73,7 +73,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.17.1"
+version = "2.18.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.csv"},
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.14.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -215,7 +215,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/ballerina/content_csv_stream.bal
+++ b/ballerina/content_csv_stream.bal
@@ -52,13 +52,13 @@ class ContentCsvStream {
     # Reads and return the next CSV record as `record{}` or `string[]`.
     #
     # + return - A record containing a `record{}` or array value when the stream is available,
-    #            `()` if the stream has reached the end or else an `error`
+    # `()` if the stream has reached the end or else an `error`
     public isolated function next() returns record {|record {}|anydata[] value;|}|error? {
         if self.isClosed {
             return;
         }
 
-        record {|record {}|anydata[] value;|}|error? nextEntry = self.csvStream.next();
+        record {|record {}|anydata[] value;|}|error? nextEntry = trap self.csvStream.next();
         if nextEntry is () {
             self.isClosed = true;
             ignoreCloseError(self.csvStream.close());
@@ -69,7 +69,7 @@ class ContentCsvStream {
             self.isClosed = true;
             ignoreCloseError(self.csvStream.close());
             return createContentBindingError("Error reading CSV stream: " + nextEntry.message(), nextEntry,
-                self.filePath);
+                    self.filePath);
         }
 
         return nextEntry;

--- a/ballerina/tests/client_endpoint_test.bal
+++ b/ballerina/tests/client_endpoint_test.bal
@@ -410,9 +410,18 @@ function testGetCsvAsStreamContentBindingError() returns error? {
     check (<Client>clientEp)->putText(path, "name,age\nAlice,\\q\nBob,25");
 
     stream<string[], error?> result = check (<Client>clientEp)->getCsvAsStream(path);
-    string[][]|error consumed = from string[] row in result
-        select row;
-    if consumed is ContentBindingError {
+    error? iterError = ();
+    while true {
+        record {|string[] value;|}|error? nextRow = result.next();
+        if nextRow is () {
+            break;
+        }
+        if nextRow is error {
+            iterError = nextRow;
+            break;
+        }
+    }
+    if iterError is ContentBindingError {
         test:assertTrue(true, msg = "getCsvAsStream should return ContentBindingError for malformed CSV");
     } else {
         test:assertFail(msg = "getCsvAsStream should return ContentBindingError for malformed CSV");
@@ -824,18 +833,21 @@ function testCsvStreamTypedBinding_strict_and_lax() returns error? {
     check (<Client>clientEp)->putCsv(csvPath, csvData, OVERWRITE);
 
     // Strict streaming should fail
-    stream<CsvPersonStrict, error?>|Error strictStreamRes = (<Client>clientEp)->getCsvAsStream(csvPath);
-    if strictStreamRes is stream<CsvPersonStrict, error?> {
+    stream<CsvPersonStrict, error?> strictStreamRes = check (<Client>clientEp)->getCsvAsStream(csvPath);
         // Try to consume the stream - should error when hitting the row with missing age
-        CsvPersonStrict[]|error consumed = from CsvPersonStrict row in strictStreamRes
-            select row;
-        test:assertTrue(consumed is ContentBindingError,
-            msg = "Strict CSV stream should return ContentBindingError on missing required field");
-    } else {
-        // Stream creation itself should fail with ContentBindingError
-        test:assertTrue(strictStreamRes is ContentBindingError,
-            msg = "Strict CSV stream should return ContentBindingError at creation");
+    error? iterError = ();
+    while true {
+        record {|CsvPersonStrict value;|}|error? nextRow = strictStreamRes.next();
+        if nextRow is () {
+            break;
+        }
+        if nextRow is error {
+            iterError = nextRow;
+            break;
+        }
     }
+    test:assertTrue(iterError is ContentBindingError,
+            msg = "Strict CSV stream should return ContentBindingError on missing required field");
 
     // Lax streaming should succeed
     stream<CsvPersonLax, error?> laxStream = check (<Client>clientEpLaxDataBinding)->getCsvAsStream(csvPath);

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["FTP", "SFTP", "remote file", "file transfer", "client", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-ftp"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.12.0"
+distribution = "2201.13.0"
 
 [platform.java21]
 graalvmCompatible = true

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [Add automatic retry support with exponential backoff for FTP listener](https://github.com/ballerina-platform/ballerina-library/issues/8585)
+- Updated minimum distribution version to 2201.13.2
 
 ### Changed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,5 +50,5 @@ stdlibFileVersion=1.12.0
 stdlibDataCsvVersion=0.8.2
 stdlibUuidVersion=1.10.0
 
-observeVersion=1.6.0
-observeInternalVersion=1.6.0
+observeVersion=1.7.0
+observeInternalVersion=1.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ stdlibTimeVersion=2.8.0
 
 # Level 2
 stdlibCryptoVersion=2.10.0
-stdlibLogVersion=2.14.0
+stdlibLogVersion=2.17.0
 stdlibOsVersion=1.10.0
 
 # Level 3

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ execForkPluginVersion=0.2.0
 
 ballerinaGradlePluginVersion=2.3.0
 
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.13.2
 
 # Level 1
 stdlibIoVersion=1.8.0


### PR DESCRIPTION
## Purpose
Update to 2021.13.2
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Distribution and Dependency Update

This PR updates the FTP Ballerina module to align with the newer Ballerina distribution and refreshes related build artifacts and dependencies to ensure compatibility.

### Key Changes
- Bumped package version to 2.18.0.
- Updated minimum Ballerina distribution requirement to 2201.13.2 (configs and build properties).
- Updated native and compiler-plugin JAR references to 2.18.0-SNAPSHOT (ftp-native and ftp-compiler-plugin).
- Bumped module/dependency versions (notable: log -> 2.17.0, observe -> 1.7.0, other stdlib bumps reflected in Dependencies.toml and gradle.properties).
- Updated build metadata and packaging paths to reference new artifact versions.
- Minor code/test adjustments: replaced use of query expressions in tests with iterative stream consumption and switched a csv stream next() call to a trapped invocation to better handle streaming errors.
- Commit message also notes a fix to patch version locking.

### Files Modified
- ballerina/Ballerina.toml
- ballerina/CompilerPlugin.toml
- ballerina/Dependencies.toml
- build-config/resources/Ballerina.toml
- gradle.properties
- changelog.md
- Updates in tests and source handling: ballerina/content_csv_stream.bal, ballerina/tests/client_endpoint_test.bal, and related test resources

Outcome: Aligns the module with distribution 2201.13.2 and updates dependencies and build artifacts to maintain compatibility and improve stability of streaming error handling. Checklist items (issue link, changelog update, tests, spec update, native-image checks) remain to be completed as indicated in the PR description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->