### PR TITLE
Fix SFTP listener blocking on shutdown due to exec channel probe

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Add automatic retry support with exponential backoff for FTP listener](https://github.com/ballerina-platform/ballerina-library/issues/8585)
 
+### Fixed
+
+- [Fix SFTP listener blocking on shutdown due to exec channel probe on restricted servers](https://github.com/ballerina-platform/ballerina-library/issues/8708)
+
 ### Changed
 
 ## [2.17.1] - 2026-02-26

--- a/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
@@ -325,6 +325,10 @@ public final class FileTransportUtils {
             }
             configBuilder.setIdentityInfo(opts, identityInfo);
         }
+        // Prevent JSch from probing server capabilities via exec channel (e.g. "id -u").
+        // Servers that expose only SFTP/SCP subsystems reject exec commands, which can stall shutdown.
+        configBuilder.setDisableDetectExecChannel(opts, true);
+
         Object avoidPermissionCheckObj = options.get(FtpConstants.AVOID_PERMISSION_CHECK);
         if (avoidPermissionCheckObj != null) {
             try {


### PR DESCRIPTION
## Summary

- Adds `setDisableDetectExecChannel(opts, true)` unconditionally for all SFTP connections to prevent JSch from probing the server with `id -u` via an exec channel.
- Separates this concern from the existing `AVOID_PERMISSION_CHECK` block, which handles strict host key checking — the two are now independent.
- Updates changelog with the fix entry.

## Root Cause

Apache Commons VFS2/JSch attempts to detect the SFTP user's home directory by running `id -u` over an SSH exec channel. Servers (e.g. Apache MINA-SSHD) that only expose SFTP/SCP subsystems reject this command:

```
WARNING: handleExec Failed (IllegalArgumentException) to create command for id -u:
Unknown command, does not begin with 'scp': id -u
```

The failed exec channel stalls during SSH session teardown, blocking `gracefulStop()` indefinitely.

## Fix

`SftpFileSystemConfigBuilder.setDisableDetectExecChannel(true)` (available since Commons VFS2 2.9.0) suppresses the probe entirely. SFTP file operations do not require exec channel capabilities.

## Test plan

- [ ] Existing SFTP listener/client tests pass
- [ ] SFTP listener shutdown no longer blocks
- [ ] No `id -u` exec warnings from the MINA-SSHD test server

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8708

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request fixes an issue where SFTP listeners could block during shutdown on servers that reject SSH exec commands.

### Changes

Root cause: Commons VFS2/JSch attempted to probe the server via an SSH exec channel to detect the user's home directory; servers exposing only SFTP/SCP subsystems can reject that probe and cause stalled sessions that block graceful shutdown.

Fix: Always disable the exec-channel probe by calling SftpFileSystemConfigBuilder.setDisableDetectExecChannel(opts, true) for all SFTP connections, separating this behavior from the existing permission-check logic. This change prevents the probe (which is unnecessary for SFTP operations) from triggering and blocking shutdown.

Files modified:
- changelog.md — adds an unreleased fix entry
- native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java — sets the disable-detect-exec-channel option when configuring SFTP

Impact: Improves stability and reliability of SFTP listener shutdown in restricted server environments. Tests: existing SFTP tests should pass; verify listener shutdown no longer blocks and no exec probe warnings from test servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->