### PR TITLE
Scope commons-lang3 as testOnly and bump stdlib patch versions

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -58,8 +58,8 @@ path = "./lib/data.jsondata-native-1.1.3.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "data.xmldata-native"
-version = "1.6.0"
-path = "./lib/data.xmldata-native-1.6.0.jar"
+version = "1.6.2"
+path = "./lib/data.xmldata-native-1.6.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ftp"
-version = "2.18.0"
+version = "2.18.1"
 authors = ["Ballerina"]
 keywords = ["FTP", "SFTP", "remote file", "file transfer", "client", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-ftp"
@@ -40,13 +40,14 @@ path = "./lib/commons-io-2.18.0.jar"
 groupId = "org.apache.commons"
 artifactId = "commons-lang3"
 version = "3.18.0"
+scope="testOnly"
 path = "./lib/commons-lang3-3.18.0.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ftp-native"
-version = "2.18.0"
-path = "../native/build/libs/ftp-native-2.18.0.jar"
+version = "2.18.1"
+path = "../native/build/libs/ftp-native-2.18.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "ftp-compiler-plugin"
 class = "io.ballerina.stdlib.ftp.plugin.FtpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.18.0.jar"
+path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.18.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -215,7 +215,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.13.2"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.0"
+version = "1.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -73,7 +73,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.18.0"
+version = "2.18.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.csv"},
@@ -223,7 +223,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.0"
+version = "1.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -40,6 +40,7 @@ path = "./lib/commons-io-@commons.io.version@.jar"
 groupId = "org.apache.commons"
 artifactId = "commons-lang3"
 version = "@commons.lang3.version@"
+scope="testOnly"
 path = "./lib/commons-lang3-@commons.lang3.version@.jar"
 
 [[platform.java21.dependency]]

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,17 +38,17 @@ stdlibTimeVersion=2.8.0
 # Level 2
 stdlibCryptoVersion=2.10.0
 stdlibLogVersion=2.17.0
-stdlibOsVersion=1.10.0
+stdlibOsVersion=1.10.1
 
 # Level 3
-stdlibTaskVersion=2.11.0
+stdlibTaskVersion=2.11.1
 stdlibDataJsonDataVersion=1.1.3
-stdlibDataXmlDataVersion=1.6.0
+stdlibDataXmlDataVersion=1.6.2
 stdlibFileVersion=1.12.0
 
 # Level 4
 stdlibDataCsvVersion=0.8.2
 stdlibUuidVersion=1.10.0
 
-observeVersion=1.7.0
+observeVersion=1.7.1
 observeInternalVersion=1.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,7 +36,7 @@ stdlibIoVersion=1.8.0
 stdlibTimeVersion=2.8.0
 
 # Level 2
-stdlibCryptoVersion=2.10.0
+stdlibCryptoVersion=2.10.1
 stdlibLogVersion=2.17.0
 stdlibOsVersion=1.10.1
 


### PR DESCRIPTION
Fixes https://github.com/wso2/product-integrator/issues/88
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/44463

## Summary
- Mark `commons-lang3` as `scope = \"testOnly\"` in the FTP bala so it isn't packaged into consumer executables (prevents the `ballerina-rt` ↔ `commons-lang3` BCE5501 conflict warning at downstream consumers).
- Refresh the auto-generated `Ballerina.toml` / `CompilerPlugin.toml` / `Dependencies.toml` to reflect the scope change.
- Bump stdlib dependencies to their latest **patch** releases:
  - `os` 1.10.0 → 1.10.1
  - `task` 2.11.0 → 2.11.1
  - `data.xmldata` 1.6.0 → 1.6.2
  - `observe` 1.7.0 → 1.7.1

## Test plan
- [ ] `./gradlew clean build` passes locally
- [ ] Consumer package that previously emitted the `commons-lang3-*.jar` conflict warning no longer does
- [ ] No regression in FTP / FTPS / SFTP connectivity (verified locally against docker-based test servers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the FTP module to improve dependency management and compatibility downstream:

**Scope Changes:**
- Marks `commons-lang3` as `scope = "testOnly"` to prevent it from being packaged into consumer executables. This eliminates a conflict warning that was occurring for downstream consumers.

**Version Updates:**
- Increments the module version from 2.18.0 to 2.18.1
- Updates stdlib patch dependencies to their latest releases:
  - `os` 1.10.0 → 1.10.1
  - `task` 2.11.0 → 2.11.1
  - `data.xmldata` 1.6.0 → 1.6.2
  - `observe` 1.7.0 → 1.7.1

**Files Modified:**
- `ballerina/Ballerina.toml` - Updates module version and adds testOnly scope to commons-lang3 dependency
- `ballerina/CompilerPlugin.toml` - Updates native JAR reference to 2.18.1-SNAPSHOT
- `ballerina/Dependencies.toml` - Refreshes dependency versions
- `build-config/resources/Ballerina.toml` - Adds testOnly scope to commons-lang3
- `gradle.properties` - Updates version properties for stdlib dependencies

The changes maintain backward compatibility while improving the dependency resolution experience for downstream consumers and ensuring access to the latest stdlib patch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->