### PR TITLE
Apply content method's afterError when binding fails

### DIFF
--- a/ballerina-tests/ftp-listener-advanced-tests/tests/ftp_listener_content_test.bal
+++ b/ballerina-tests/ftp-listener-advanced-tests/tests/ftp_listener_content_test.bal
@@ -760,3 +760,203 @@ function testFunctionConfig_AfterErrorDelete() returns error? {
     test:assertTrue(exists is boolean && !<boolean>exists,
         "afterError=DELETE should remove the file when the handler returns an error");
 }
+
+// Regression tests for https://github.com/wso2/product-integrator/issues/1161.
+// When strict CSV binding raises a ContentBindingError the file must be routed to the content
+// method's afterError directory (or to the onError method's own post-process action when
+// declared). Previously the listener dispatched to onError but never honoured the content
+// method's own afterError, so the corrupted file was left in the source directory and
+// re-picked on every poll.
+type CorruptCsvContent record {|
+    string name;
+    int age;
+    string gender;
+|};
+
+const string CORRUPT_CSV_DIR = "/home/in/adv-postproc-corrupt-csv";
+const string CORRUPT_CSV_PROCESSED_DIR = "/home/in/adv-postproc-corrupt-csv-processed";
+const string CORRUPT_CSV_ERROR_DIR = "/home/in/adv-postproc-corrupt-csv-error";
+
+// Header is missing the required `age` column — strict binding to CorruptCsvContent must fail.
+const string CORRUPT_CSV_PAYLOAD = "name,sex,gender\n" +
+    "Alice Johnson,28,Female\n" +
+    "Bob Martinez,34,Male\n";
+
+isolated boolean corruptCsvHandlerInvoked = false;
+isolated boolean onErrorCorruptCsvInvoked = false;
+isolated boolean corruptCsvHandlerB = false;
+isolated boolean corruptCsvHandlerC = false;
+isolated boolean corruptCsvOnErrorC = false;
+
+function waitUntilFileAt(string path) returns boolean {
+    return waitUntil(function() returns boolean {
+        boolean|ftp:Error exists = contentFtpClient->exists(path);
+        return exists is boolean && <boolean>exists;
+    }, 30);
+}
+
+// No onError declared → content method's afterError must fire and move the file to /error.
+@test:Config {
+    groups: ["ftp-listener-advanced", "function-config"],
+    dependsOn: [testFunctionConfig_AfterErrorDelete]
+}
+function testFunctionConfig_CorruptCsvRoutesToAfterError() returns error? {
+    lock { corruptCsvHandlerInvoked = false; }
+
+    ftp:Service svc = service object {
+        @ftp:FunctionConfig {
+            afterProcess: {moveTo: CORRUPT_CSV_PROCESSED_DIR},
+            afterError: {moveTo: CORRUPT_CSV_ERROR_DIR}
+        }
+        remote function onFileCsv(CorruptCsvContent[] contents, ftp:FileInfo fileInfo) returns error? {
+            lock { corruptCsvHandlerInvoked = true; }
+        }
+    };
+
+    ftp:Listener l = check new (contentListenerConfig(CORRUPT_CSV_DIR, "cbe-noonerr.*\\.csv", 2));
+    check l.attach(svc);
+    check l.'start();
+    runtime:registerListener(l);
+
+    string remotePath = CORRUPT_CSV_DIR + "/cbe-noonerr.csv";
+    string movedPath = CORRUPT_CSV_ERROR_DIR + "/cbe-noonerr.csv";
+    check contentFtpClient->putText(remotePath, CORRUPT_CSV_PAYLOAD);
+
+    boolean moved = waitUntilFileAt(movedPath);
+
+    runtime:deregisterListener(l);
+    check l.gracefulStop();
+
+    boolean handlerCalled;
+    lock { handlerCalled = corruptCsvHandlerInvoked; }
+    test:assertFalse(handlerCalled,
+        "onFileCsv must not be invoked when CSV headers do not satisfy the target record type");
+    test:assertTrue(moved, "Corrupted CSV should be moved to the afterError directory");
+
+    boolean inSource = check contentFtpClient->exists(remotePath);
+    test:assertFalse(inSource,
+        "Corrupted CSV must be removed from the source directory (the core regression)");
+
+    boolean inProcessed = check contentFtpClient->exists(CORRUPT_CSV_PROCESSED_DIR + "/cbe-noonerr.csv");
+    test:assertFalse(inProcessed, "Corrupted CSV must not be moved to the afterProcess directory");
+
+    check contentFtpClient->delete(movedPath);
+}
+
+// onError declared without its own post-process actions → fall back to the content method's
+// afterError, and onError is still invoked for notification.
+@test:Config {
+    groups: ["ftp-listener-advanced", "function-config"],
+    dependsOn: [testFunctionConfig_CorruptCsvRoutesToAfterError]
+}
+function testFunctionConfig_CorruptCsv_OnErrorWithoutActions() returns error? {
+    lock { onErrorCorruptCsvInvoked = false; }
+    lock { corruptCsvHandlerB = false; }
+
+    ftp:Service svc = service object {
+        @ftp:FunctionConfig {
+            afterProcess: {moveTo: CORRUPT_CSV_PROCESSED_DIR},
+            afterError: {moveTo: CORRUPT_CSV_ERROR_DIR}
+        }
+        remote function onFileCsv(CorruptCsvContent[] contents, ftp:FileInfo fileInfo) returns error? {
+            lock { corruptCsvHandlerB = true; }
+        }
+
+        remote function onError(ftp:Error err) returns error? {
+            lock { onErrorCorruptCsvInvoked = true; }
+        }
+    };
+
+    ftp:Listener l = check new (contentListenerConfig(CORRUPT_CSV_DIR, "cbe-onerr-noact.*\\.csv", 2));
+    check l.attach(svc);
+    check l.'start();
+    runtime:registerListener(l);
+
+    string remotePath = CORRUPT_CSV_DIR + "/cbe-onerr-noact.csv";
+    string movedPath = CORRUPT_CSV_ERROR_DIR + "/cbe-onerr-noact.csv";
+    check contentFtpClient->putText(remotePath, CORRUPT_CSV_PAYLOAD);
+
+    boolean moved = waitUntilFileAt(movedPath);
+
+    runtime:deregisterListener(l);
+    check l.gracefulStop();
+
+    boolean onErrorCalled;
+    lock { onErrorCalled = onErrorCorruptCsvInvoked; }
+    boolean handlerCalled;
+    lock { handlerCalled = corruptCsvHandlerB; }
+    test:assertFalse(handlerCalled,
+        "onFileCsv must not be invoked when binding fails");
+    test:assertTrue(onErrorCalled, "onError should be invoked for a ContentBindingError");
+    test:assertTrue(moved,
+        "Corrupted CSV should fall back to the content method's afterError directory");
+
+    boolean inSource = check contentFtpClient->exists(remotePath);
+    test:assertFalse(inSource,
+        "Corrupted CSV must be removed from the source directory (the core regression)");
+
+    check contentFtpClient->delete(movedPath);
+}
+
+// onError declared with its own afterProcess; onError returns success → onError's
+// afterProcess wins; content method's afterError is suppressed.
+@test:Config {
+    groups: ["ftp-listener-advanced", "function-config"],
+    dependsOn: [testFunctionConfig_CorruptCsv_OnErrorWithoutActions]
+}
+function testFunctionConfig_CorruptCsv_OnErrorWithOwnActions() returns error? {
+    lock { corruptCsvHandlerC = false; }
+    lock { corruptCsvOnErrorC = false; }
+
+    ftp:Service svc = service object {
+        @ftp:FunctionConfig {
+            afterProcess: {moveTo: CORRUPT_CSV_PROCESSED_DIR},
+            afterError: {moveTo: CORRUPT_CSV_ERROR_DIR}
+        }
+        remote function onFileCsv(CorruptCsvContent[] contents, ftp:FileInfo fileInfo) returns error? {
+            lock { corruptCsvHandlerC = true; }
+        }
+
+        @ftp:FunctionConfig {
+            afterProcess: {moveTo: CORRUPT_CSV_PROCESSED_DIR}
+        }
+        remote function onError(ftp:Error err) returns error? {
+            lock { corruptCsvOnErrorC = true; }
+        }
+    };
+
+    ftp:Listener l = check new (contentListenerConfig(CORRUPT_CSV_DIR, "cbe-onerr-act.*\\.csv", 2));
+    check l.attach(svc);
+    check l.'start();
+    runtime:registerListener(l);
+
+    string remotePath = CORRUPT_CSV_DIR + "/cbe-onerr-act.csv";
+    string movedPath = CORRUPT_CSV_PROCESSED_DIR + "/cbe-onerr-act.csv";
+    check contentFtpClient->putText(remotePath, CORRUPT_CSV_PAYLOAD);
+
+    boolean moved = waitUntilFileAt(movedPath);
+
+    runtime:deregisterListener(l);
+    check l.gracefulStop();
+
+    boolean handlerCalled;
+    lock { handlerCalled = corruptCsvHandlerC; }
+    boolean onErrorCalled;
+    lock { onErrorCalled = corruptCsvOnErrorC; }
+    test:assertFalse(handlerCalled,
+        "onFileCsv must not be invoked when binding fails (ensures the binding-failure path is exercised)");
+    test:assertTrue(onErrorCalled,
+        "onError must be invoked for a ContentBindingError");
+    test:assertTrue(moved,
+        "onError's afterProcess should govern when it declares its own post-process action");
+
+    boolean inSource = check contentFtpClient->exists(remotePath);
+    test:assertFalse(inSource,
+        "Corrupted CSV must be removed from the source directory (the core regression)");
+
+    boolean inContentError = check contentFtpClient->exists(CORRUPT_CSV_ERROR_DIR + "/cbe-onerr-act.csv");
+    test:assertFalse(inContentError,
+        "Content method's afterError must be suppressed when onError declares the afterProcess slot");
+
+    check contentFtpClient->delete(movedPath);
+}

--- a/ballerina/annotations.bal
+++ b/ballerina/annotations.bal
@@ -39,7 +39,12 @@ public type FtpFunctionConfig record {|
     # If not specified, no action is taken (file remains in place)
     MOVE|DELETE afterProcess?;
     # Action to perform after a processing error. Can be `DELETE` or `MOVE`.
-    # Executed immediately after the content handler returns an error or panics.
+    # Executed immediately after the content handler returns an error or panics,
+    # or when content binding fails before the handler is invoked (e.g. malformed
+    # CSV/JSON/XML for the target type). On binding failures, any slot an
+    # `onError` method declares (`afterProcess` or `afterError` on its own
+    # `FunctionConfig`) takes precedence; slots it leaves empty fall back to
+    # this action.
     # If not specified, no action is taken (file remains in place)
     MOVE|DELETE afterError?;
 |};

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## unreleased
 
+### Fixed
+
+- [Apply the content method's `afterError` action when content binding fails before the handler is invoked](https://github.com/wso2/product-integrator/issues/1161)
+
 ### Changed
 
 - Restructure the Ballerina test suite into per-protocol and per-feature test projects under `ballerina-tests/`, with an isolated advisory-mode project for timing-sensitive (file-age/file-dependency) tests

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -75,6 +75,8 @@ import static io.ballerina.stdlib.ftp.util.FtpContentConverter.deriveFileNamePre
 public class FtpContentCallbackHandler {
 
     private static final Logger log = LoggerFactory.getLogger(FtpContentCallbackHandler.class);
+    private static final String ACTION_AFTER_PROCESS = "afterProcess";
+    private static final String ACTION_AFTER_ERROR = "afterError";
     private final Runtime ballerinaRuntime;
     private final FileSystemManager fileSystemManager;
     private final FileSystemOptions fileSystemOptions;
@@ -131,7 +133,8 @@ public class FtpContentCallbackHandler {
 
                 if (convertedContent instanceof BError bError) {
                     if (FtpUtil.ErrorType.ContentBindingError.errorType().equals(bError.getType().getName())) {
-                        routeToOnError(service, holder, bError, callerObject, fileInfo, listenerPath);
+                        routeToOnError(service, holder, bError, callerObject, fileInfo, listenerPath,
+                                methodType.getName());
                     } else {
                         bError.printStackTrace();
                     }
@@ -304,16 +307,17 @@ public class FtpContentCallbackHandler {
     }
 
     private void routeToOnError(BObject service, FormatMethodsHolder holder, BError error, BObject callerObject,
-                                FileInfo fileInfo, String listenerPath) {
-        if (!holder.hasOnErrorMethod()) {
-            // No onError handler, error is already logged
-            error.printStackTrace();
-            return;
-        }
+                                FileInfo fileInfo, String listenerPath, String contentMethodName) {
+        // Binding failed before the content handler ran — the content method's afterError is the
+        // user's declared "corrupted file" destination. It is the fallback for any post-process
+        // slot the onError method's @FunctionConfig does not declare.
+        Optional<PostProcessAction> contentAfterError = holder.getAfterErrorAction(contentMethodName);
 
         Optional<MethodType> onErrorMethodOpt = holder.getOnErrorMethod();
         if (onErrorMethodOpt.isEmpty()) {
             error.printStackTrace();
+            contentAfterError.ifPresent(action -> Thread.startVirtualThread(() ->
+                    executePostProcessAction(action, fileInfo, callerObject, listenerPath, ACTION_AFTER_ERROR)));
             return;
         }
 
@@ -321,16 +325,18 @@ public class FtpContentCallbackHandler {
 
         Optional<PostProcessAction> onErrorAfterProcess = holder.getAfterProcessAction(onErrorMethod.getName());
         Optional<PostProcessAction> onErrorAfterError = holder.getAfterErrorAction(onErrorMethod.getName());
-        boolean hasOnErrorActions = onErrorAfterProcess.isPresent() || onErrorAfterError.isPresent();
 
-        // Prepare arguments for onError method
+        // Per slot: honour what onError declares; fall back to the content method's afterError
+        // for any slot onError left empty. The source file already failed binding, so an empty
+        // slot must not mean "do nothing" — it means "use the content method's afterError".
+        Optional<PostProcessAction> effectiveAfterProcess =
+                onErrorAfterProcess.isPresent() ? onErrorAfterProcess : contentAfterError;
+        Optional<PostProcessAction> effectiveAfterError =
+                onErrorAfterError.isPresent() ? onErrorAfterError : contentAfterError;
+
         Object[] methodArguments = prepareOnErrorMethodArguments(onErrorMethod, error, callerObject);
-
-        // Invoke onError asynchronously and apply afterProcess/afterError actions
         invokeOnErrorMethodAsync(service, onErrorMethod.getName(), methodArguments, fileInfo, callerObject,
-                listenerPath,
-                hasOnErrorActions ? onErrorAfterProcess : Optional.empty(),
-                hasOnErrorActions ? onErrorAfterError : Optional.empty());
+                listenerPath, effectiveAfterProcess, effectiveAfterError);
     }
 
     private Object[] prepareOnErrorMethodArguments(MethodType methodType, BError error, BObject callerObject) {
@@ -371,10 +377,10 @@ public class FtpContentCallbackHandler {
 
             if (isSuccess) {
                 afterProcess.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, "afterProcess"));
+                        listenerPath, ACTION_AFTER_PROCESS));
             } else {
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, "afterError"));
+                        listenerPath, ACTION_AFTER_ERROR));
             }
         });
     }
@@ -396,7 +402,7 @@ public class FtpContentCallbackHandler {
                     ((BError) result).printStackTrace();
                     // Method returned an error - execute afterError action
                     afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                            listenerPath, "afterError"));
+                            listenerPath, ACTION_AFTER_ERROR));
                 } else {
                     isSuccess = true;
                 }
@@ -404,19 +410,19 @@ public class FtpContentCallbackHandler {
                 error.printStackTrace();
                 // Method threw an error - execute afterError action
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, "afterError"));
+                        listenerPath, ACTION_AFTER_ERROR));
             } catch (Exception exception) {
                 FtpUtil.createError("Error invoking content method: " + methodName + " - " + exception.getMessage(),
                         exception, FtpConstants.FTP_ERROR).printStackTrace();
                 // Method threw an exception - execute afterError action
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, "afterError"));
+                        listenerPath, ACTION_AFTER_ERROR));
             }
 
             // Execute afterProcess action on success
             if (isSuccess) {
                 afterProcess.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, "afterProcess"));
+                        listenerPath, ACTION_AFTER_PROCESS));
             }
         });
     }

--- a/test-utils/src/main/java/io/ballerina/stdlib/ftp/testutils/mockServerUtils/MockFtpServer.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/ftp/testutils/mockServerUtils/MockFtpServer.java
@@ -119,6 +119,9 @@ public final class MockFtpServer {
         fileSystem.add(new DirectoryEntry("/home/in/adv-postproc"));
         fileSystem.add(new DirectoryEntry("/home/in/adv-postproc-done"));
         fileSystem.add(new DirectoryEntry("/home/in/adv-postproc-after-error"));
+        fileSystem.add(new DirectoryEntry("/home/in/adv-postproc-corrupt-csv"));
+        fileSystem.add(new DirectoryEntry("/home/in/adv-postproc-corrupt-csv-processed"));
+        fileSystem.add(new DirectoryEntry("/home/in/adv-postproc-corrupt-csv-error"));
 
         // ftp-listener-advanced-tests: onError
         fileSystem.add(new DirectoryEntry("/home/in/adv-onerror"));


### PR DESCRIPTION
Fixes [wso2/product-integrator#1161](https://github.com/wso2/product-integrator/issues/1161).

## Summary

When content binding failed before the handler could run (e.g. strict CSV/JSON/XML parsing against a record type), `routeToOnError` dispatched to the user's `onError` handler but never applied the content method's `afterError` post-process action. With no fallback for _"we know which method this file should have gone to but couldn't invoke it"_, the corrupted file stayed in the source directory and was re-picked on every poll.

`csvFailSafe` behaviour is unchanged — opting in still means "log malformed rows and continue with partial data" as designed.

## Fix

Pass the content method name into `routeToOnError` and treat the content method's `afterError` as the fallback destination for the source file:

- **No `onError` declared** → apply the content method's `afterError` immediately.
- **`onError` declared with its own `afterProcess`/`afterError`** → existing behaviour; those actions drive the file based on `onError`'s outcome.
- **`onError` declared without actions** → apply the content method's `afterError` regardless of `onError`'s outcome, since the source file already failed binding.

Exactly one post-process action fires per file.

## Verified end-to-end (dockerised FTP)

| # | trigger | content cfg | onError cfg | expected | result |
|---|---|---|---|---|---|
| 1 | Handler OK | afterProcess=MOVE/proc | — | `/proc` | ✓ |
| 2 | Handler returns error | afterError=MOVE/err | — | `/err` | ✓ |
| 4a | Binding fails | afterError=MOVE/err | no onError | `/err` (content fallback) | ✓ |
| 4b | Binding fails | afterError=MOVE/err | onError, no actions | `/err` (content fallback) | ✓ |
| 4c | Binding fails | afterError=MOVE/err | onError + afterError=DELETE, onError errs | deleted (onError wins) | ✓ |
| 4d | Binding fails | afterError=MOVE/err | onError + afterProcess=MOVE/B, onError OK | `/B` (onError wins) | ✓ |

## Docs / tests

- Updated the `afterError` Ballerina doc in `annotations.bal` to reflect binding-failure routing and the `onError`-takes-precedence rule.
- Added regression test `testFunctionConfig_CorruptCsvRoutesToAfterError` in `ballerina-tests/ftp-listener-advanced-tests/tests/ftp_listener_content_test.bal`.

## Test plan

- [x] `./gradlew :ftp-native:compileJava :ftp-native:checkstyleMain`
- [x] End-to-end reproduction against a Dockerised FTP server for all six rows above.
- [ ] Regression test needs the CI FTP harness to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a routing issue where files that fail content binding or parsing (e.g., CSV/JSON/XML parsing failures against a record type) were not properly routed to the configured error handling path. Previously, such corrupted files would remain in the source directory and be re-picked on subsequent polls, rather than being moved to the configured `afterError` destination.

## Changes

The implementation passes the content method name into error routing and establishes the content method's `afterError` action as the fallback destination for source files when binding fails:

**Behavior rules:**
- When no `onError` handler is declared, the content method's `afterError` action is applied immediately
- When an `onError` handler is declared with its own `afterProcess` or `afterError` actions, those take precedence
- When an `onError` handler is declared without its own post-process actions, the handler is invoked while the file still falls back to the content method's `afterError`

**Implementation approach:**
- Uses per-slot fallback pattern where `effectiveAfterProcess` and `effectiveAfterError` independently fall back to content `afterError` when the corresponding `onError` slot is empty
- Ensures exactly one post-process action fires per file
- Does not affect `csvFailSafe` behavior

## Testing & Verification

Added three regression tests covering strict typed CSV binding failures and verifying correct post-processing routing across all scenario combinations. Tests verify that corrupted files are:
- Removed from the source directory
- Moved to appropriate destinations based on handler configuration
- Handled correctly with and without `onError` handlers

End-to-end verification was performed against a dockerized FTP server across handler success, handler error, and multiple binding-failure scenarios.

## Documentation

Updated the `FtpFunctionConfig.afterError` documentation to clarify behavior when content binding fails and to define precedence rules for post-processing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->