### PR TITLE
Validate fileAgeFilter values at listener startup

### DIFF
--- a/ballerina-tests/ftp-listener-timing-tests/tests/ftp_listener_file_age_test.bal
+++ b/ballerina-tests/ftp-listener-timing-tests/tests/ftp_listener_file_age_test.bal
@@ -343,3 +343,102 @@ function testFileAgeFilter_CreationTimeMode_FallsBackToLastModified() returns er
 
     deleteIfExistsAge(ageFtpClient, AGE_MAX_DIR + "/fresh.ctfb");
 }
+
+// ─── TEST: negative minAge → attach returns InvalidConfigError ─────────────────
+
+@test:Config {
+    groups: ["ftp-listener-behaviour", "file-age-filter"]
+}
+function testFileAgeFilter_NegativeMinAge_RejectedAtAttach() returns error? {
+    ftp:Service svc = @ftp:ServiceConfig {
+        path: AGE_MAX_DIR,
+        fileAgeFilter: {minAge: -5.0}
+    }
+    service object {
+        remote function onFileChange(ftp:WatchEvent & readonly event) {}
+    };
+
+    ftp:Listener l = check new ({
+        protocol: ftp:FTP,
+        host: commons:FTP_HOST,
+        port: commons:AUTH_FTP_PORT,
+        auth: {credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD}},
+        pollingInterval: 2
+    });
+
+    error? result = l.attach(svc);
+    check l.immediateStop();
+
+    test:assertTrue(result is ftp:InvalidConfigError,
+        "attach() should return InvalidConfigError for negative minAge");
+    if result is ftp:InvalidConfigError {
+        test:assertTrue(result.message().includes("minAge"),
+            "Error message should mention minAge");
+    }
+}
+
+// ─── TEST: negative maxAge → attach returns InvalidConfigError ─────────────────
+
+@test:Config {
+    groups: ["ftp-listener-behaviour", "file-age-filter"]
+}
+function testFileAgeFilter_NegativeMaxAge_RejectedAtAttach() returns error? {
+    ftp:Service svc = @ftp:ServiceConfig {
+        path: AGE_MAX_DIR,
+        fileAgeFilter: {maxAge: -10.0}
+    }
+    service object {
+        remote function onFileChange(ftp:WatchEvent & readonly event) {}
+    };
+
+    ftp:Listener l = check new ({
+        protocol: ftp:FTP,
+        host: commons:FTP_HOST,
+        port: commons:AUTH_FTP_PORT,
+        auth: {credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD}},
+        pollingInterval: 2
+    });
+
+    error? result = l.attach(svc);
+    check l.immediateStop();
+
+    test:assertTrue(result is ftp:InvalidConfigError,
+        "attach() should return InvalidConfigError for negative maxAge");
+    if result is ftp:InvalidConfigError {
+        test:assertTrue(result.message().includes("maxAge"),
+            "Error message should mention maxAge");
+    }
+}
+
+// ─── TEST: minAge > maxAge → attach returns InvalidConfigError ─────────────────
+
+@test:Config {
+    groups: ["ftp-listener-behaviour", "file-age-filter"]
+}
+function testFileAgeFilter_MinAgeExceedsMaxAge_RejectedAtAttach() returns error? {
+    ftp:Service svc = @ftp:ServiceConfig {
+        path: AGE_MAX_DIR,
+        fileAgeFilter: {minAge: 100.0, maxAge: 10.0}
+    }
+    service object {
+        remote function onFileChange(ftp:WatchEvent & readonly event) {}
+    };
+
+    ftp:Listener l = check new ({
+        protocol: ftp:FTP,
+        host: commons:FTP_HOST,
+        port: commons:AUTH_FTP_PORT,
+        auth: {credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD}},
+        pollingInterval: 2
+    });
+
+    error? result = l.attach(svc);
+    check l.immediateStop();
+
+    test:assertTrue(result is ftp:InvalidConfigError,
+        "attach() should return InvalidConfigError when minAge exceeds maxAge");
+    if result is ftp:InvalidConfigError {
+        test:assertTrue(result.message().includes("must not exceed"),
+            "Error message should explain minAge cannot exceed maxAge");
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Apply the content method's `afterError` action when content binding fails before the handler is invoked](https://github.com/wso2/product-integrator/issues/1161)
+- [Validate `fileAgeFilter` values at listener startup; reject negative `minAge`/`maxAge` and `minAge` greater than `maxAge`](https://github.com/wso2/product-integrator/issues/1151)
 
 ### Changed
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -627,7 +627,9 @@ The `fileNamePattern` field in `@ftp:ServiceConfig` accepts a Java regular expre
 
 #### 4.5.2 File Age Filter
 
-The `fileAgeFilter` in `@ftp:ServiceConfig` allows filtering files based on how recently they were last modified. This is useful for skipping files that are still being written by an upstream process. The filter specifies a minimum age (in seconds); files newer than this threshold are excluded from triggering events.
+The `fileAgeFilter` in `@ftp:ServiceConfig` filters files based on their age. `minAge` (in seconds) skips files younger than the threshold — useful for ignoring files still being written by an upstream process. `maxAge` (in seconds) skips files older than the threshold. Either bound may be set independently; both are optional.
+
+Both values are validated when the listener starts. The listener fails with an `InvalidConfigError` if `minAge` or `maxAge` is negative, or if `minAge` exceeds `maxAge`.
 
 #### 4.5.3 File Dependency Conditions
 

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
@@ -498,7 +498,8 @@ public class FtpListenerHelper {
     /**
      * Parses file age filter into ServiceConfiguration.Builder using the shared extraction logic.
      */
-    private static void parseFileAgeFilter(BMap<BString, Object> ageFilter, ServiceConfiguration.Builder builder) {
+    private static void parseFileAgeFilter(BMap<BString, Object> ageFilter, ServiceConfiguration.Builder builder)
+            throws FtpInvalidConfigException {
         Map<String, Object> ageParams = new HashMap<>();
         addAgeFilterValues(ageFilter, ageParams);
 
@@ -721,7 +722,8 @@ public class FtpListenerHelper {
         extractProxyConfiguration(serviceEndpointConfig, params);
     }
 
-    private static void addFileAgeFilterParams(BMap serviceEndpointConfig, Map<String, Object> params) {
+    private static void addFileAgeFilterParams(BMap serviceEndpointConfig, Map<String, Object> params)
+            throws FtpInvalidConfigException {
         BMap fileAgeFilter = serviceEndpointConfig.getMapValue(
                 StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_FILE_AGE_FILTER));
         if (fileAgeFilter != null) {
@@ -733,13 +735,18 @@ public class FtpListenerHelper {
      * Extracts minAge, maxAge and ageCalculationMode from a fileAgeFilter record into params.
      * Shared by both listener-level and service-level config processing.
      */
-    private static void addAgeFilterValues(BMap ageFilter, Map<String, Object> params) {
+    private static void addAgeFilterValues(BMap ageFilter, Map<String, Object> params)
+            throws FtpInvalidConfigException {
         Object minAgeObj = ageFilter.get(StringUtils.fromString(FtpConstants.FILE_AGE_FILTER_MIN_AGE));
+        Object maxAgeObj = ageFilter.get(StringUtils.fromString(FtpConstants.FILE_AGE_FILTER_MAX_AGE));
+
+        Double minAge = (minAgeObj != null) ? ((BDecimal) minAgeObj).floatValue() : null;
+        Double maxAge = (maxAgeObj != null) ? ((BDecimal) maxAgeObj).floatValue() : null;
+        FtpUtil.validateFileAgeFilter(minAge, maxAge);
+
         if (minAgeObj != null) {
             params.put(FtpConstants.FILE_AGE_FILTER_MIN_AGE, String.valueOf(minAgeObj));
         }
-
-        Object maxAgeObj = ageFilter.get(StringUtils.fromString(FtpConstants.FILE_AGE_FILTER_MAX_AGE));
         if (maxAgeObj != null) {
             params.put(FtpConstants.FILE_AGE_FILTER_MAX_AGE, String.valueOf(maxAgeObj));
         }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpUtil.java
@@ -143,6 +143,28 @@ public class FtpUtil {
         }
     }
 
+    /**
+     * Validates fileAgeFilter values: rejects negatives and minAge greater than maxAge.
+     *
+     * @param minAge parsed minAge in seconds, or null if unset
+     * @param maxAge parsed maxAge in seconds, or null if unset
+     * @throws FtpInvalidConfigException if either value is negative or minAge exceeds maxAge
+     */
+    public static void validateFileAgeFilter(Double minAge, Double maxAge) throws FtpInvalidConfigException {
+        if (minAge != null && minAge < 0) {
+            throw new FtpInvalidConfigException(
+                    "fileAgeFilter.minAge must be positive or zero (got: " + minAge + ")");
+        }
+        if (maxAge != null && maxAge < 0) {
+            throw new FtpInvalidConfigException(
+                    "fileAgeFilter.maxAge must be positive or zero (got: " + maxAge + ")");
+        }
+        if (minAge != null && maxAge != null && minAge > maxAge) {
+            throw new FtpInvalidConfigException(
+                    "fileAgeFilter.minAge (" + minAge + ") must not exceed fileAgeFilter.maxAge (" + maxAge + ")");
+        }
+    }
+
     public static void extractFileTransferConfiguration(BMap<Object, Object> config,
                                                         Map<String, Object> ftpProperties) {
         // Update to the new constant


### PR DESCRIPTION
## Purpose
Closes wso2/product-integrator#1151.

`ftp:FileAgeFilter` previously accepted any numeric `minAge` / `maxAge` without validation. As reported in the issue, a service configured with `minAge: 100, maxAge: 10` would start cleanly but never deliver a file, and negative values were silently accepted (effectively disabling the lower/upper bound).

## Approach
Validation lives in `FtpUtil.validateFileAgeFilter`, mirroring the existing `validateTimeout` / `validateRegexPattern` pattern. It is invoked from `FtpListenerHelper.addAgeFilterValues` — the single chokepoint both listener-level and `@ftp:ServiceConfig` parse paths flow through — so the downstream `RemoteFileSystemConsumer` receives pre-validated values.

The listener now fails fast at startup (`InvalidConfigError`) when:
- `minAge < 0`
- `maxAge < 0`
- `minAge > maxAge`

## Test plan
- [x] Negative `minAge` → `attach()` returns `ftp:InvalidConfigError`
- [x] Negative `maxAge` → `attach()` returns `ftp:InvalidConfigError`
- [x] `minAge > maxAge` → `attach()` returns `ftp:InvalidConfigError`
- [x] Existing `fileAgeFilter` behaviour tests still pass

Tests added in `ballerina-tests/ftp-listener-timing-tests/tests/ftp_listener_file_age_test.bal`.