### PR TITLE
Improve key/cert error messages and validation for FTPS and SFTP

### DIFF
--- a/ballerina-tests/ftps-connection-tests/tests/ftps_connection_test.bal
+++ b/ballerina-tests/ftps-connection-tests/tests/ftps_connection_test.bal
@@ -315,6 +315,122 @@ function testFtpsConnectWithWrongKeystorePassword() {
         "Expected error for wrong keystore password");
 }
 
+// An empty string keystore path must be rejected at client init, matching
+// the listener-side validation.
+@test:Config {
+    groups: ["ftps-connection", "negative"]
+}
+function testFtpsConnectWithEmptyKeystorePath() {
+    ftp:Client|ftp:Error result = new ({
+        protocol: ftp:FTPS,
+        host: commons:FTP_HOST,
+        port: commons:FTPS_EXPLICIT_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            secureSocket: {
+                key: {path: "", password: "changeit"},
+                cert: {path: commons:KEYSTORE_PATH, password: "changeit"},
+                mode: ftp:EXPLICIT
+            }
+        }
+    });
+    // Invariant: rejected at client init as a config error, not propagated as a
+    // connection failure. Exact wording is not part of the contract.
+    test:assertTrue(result is ftp:InvalidConfigError,
+            "Expected InvalidConfigError for empty keystore path");
+}
+
+// An empty string truststore path must be rejected at client init.
+@test:Config {
+    groups: ["ftps-connection", "negative"]
+}
+function testFtpsConnectWithEmptyTruststorePath() {
+    ftp:Client|ftp:Error result = new ({
+        protocol: ftp:FTPS,
+        host: commons:FTP_HOST,
+        port: commons:FTPS_EXPLICIT_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            secureSocket: {
+                key: {path: commons:KEYSTORE_PATH, password: "changeit"},
+                cert: {path: "", password: "changeit"},
+                mode: ftp:EXPLICIT
+            }
+        }
+    });
+    test:assertTrue(result is ftp:InvalidConfigError,
+            "Expected InvalidConfigError for empty truststore path");
+}
+
+// An empty (zero-byte) keystore file used to surface a message ending in
+// literal "null" (getMessage() returned null from the JVM). Pre-validation
+// now catches this up front with a clear reason.
+@test:Config {
+    groups: ["ftps-connection", "negative"]
+}
+function testFtpsConnectWithEmptyKeystoreFile() {
+    ftp:Client|ftp:Error result = new ({
+        protocol: ftp:FTPS,
+        host: commons:FTP_HOST,
+        port: commons:FTPS_EXPLICIT_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            secureSocket: {
+                key: {path: commons:RESOURCES_PATH + "/datafiles/empty.jks", password: "changeit"},
+                cert: {path: commons:KEYSTORE_PATH, password: "changeit"},
+                mode: ftp:EXPLICIT
+            }
+        }
+    });
+    test:assertTrue(result is ftp:Error,
+            "Expected error for empty (0-byte) keystore file");
+    if result is ftp:Error {
+        // Invariants (not exact phrasing):
+        //   1. The configured path is named so the user can find the bad file.
+        //   2. The message is not the bare "... null" that the JVM used to surface
+        //      when the wrapped exception had no message (product-integrator#831).
+        test:assertTrue(result.message().includes("empty.jks"),
+                "Error should name the configured path: " + result.message());
+        test:assertFalse(result.message().endsWith(". null") || result.message().endsWith(": null"),
+                "Error must not end with a literal 'null': " + result.message());
+    }
+}
+
+// A PEM file passed where a JKS keystore is expected used to leak the
+// cryptic "toDerInputStream rejects tag type 45". File-header sniffing
+// now surfaces a clear PEM-specific error.
+@test:Config {
+    groups: ["ftps-connection", "negative"]
+}
+function testFtpsConnectWithPemAsKeystore() {
+    ftp:Client|ftp:Error result = new ({
+        protocol: ftp:FTPS,
+        host: commons:FTP_HOST,
+        port: commons:FTPS_EXPLICIT_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            secureSocket: {
+                key: {path: commons:RESOURCES_PATH + "/sftp.passwordless.private.key", password: "changeit"},
+                cert: {path: commons:KEYSTORE_PATH, password: "changeit"},
+                mode: ftp:EXPLICIT
+            }
+        }
+    });
+    test:assertTrue(result is ftp:Error,
+            "Expected error for PEM file passed as keystore");
+    if result is ftp:Error {
+        // Invariants (not exact phrasing):
+        //   1. The configured path is named.
+        //   2. The raw JVM "toDerInputStream rejects tag type" message must not
+        //      leak through — either the PEM pre-sniff catches it or the generic
+        //      fallback produces something clean.
+        test:assertTrue(result.message().includes("sftp.passwordless.private.key"),
+                "Error should name the configured path: " + result.message());
+        test:assertFalse(result.message().includes("toDerInputStream rejects tag type"),
+                "Error must not leak the raw JVM keystore-parse message: " + result.message());
+    }
+}
+
 // =============================================================================
 // Negative: unreachable server
 // =============================================================================

--- a/ballerina-tests/sftp-connection-tests/tests/sftp_connection_test.bal
+++ b/ballerina-tests/sftp-connection-tests/tests/sftp_connection_test.bal
@@ -340,7 +340,8 @@ function testSftpConnectWithUnregisteredKey() {
     }
 }
 
-// A key path that does not exist on disk.
+// A key path that does not exist on disk: pre-validation names the path and
+// the reason instead of letting JSch leak an IdentityInfo@<hash> toString.
 @test:Config {
     groups: ["sftp-connection", "negative"]
 }
@@ -357,8 +358,94 @@ function testSftpConnectWithInvalidKeyPath() {
     test:assertTrue(result is ftp:Error,
             "Expected error for non-existent SFTP key path");
     if result is ftp:Error {
-        test:assertTrue(result.message().startsWith("Error while connecting to the FTP server with URL: "),
-                "Unexpected error message: " + result.message());
+        // Invariants (not exact phrasing):
+        //   1. The configured path appears so the user can see what was misconfigured.
+        //   2. JSch's "IdentityInfo@<hash>" object identity does not leak
+        //      (ballerina-library#8760).
+        test:assertTrue(result.message().includes("tests/resources/nonexistent.private.key"),
+                "Error should name the configured key path: " + result.message());
+        test:assertFalse(result.message().includes("IdentityInfo@"),
+                "Error must not leak the JSch IdentityInfo object identity: "
+                + result.message());
+    }
+}
+
+// An empty string privateKey.path must be rejected at client init with a
+// clear InvalidConfigError, not slipped into VFS where it turns into a
+// cryptic IdentityInfo failure.
+@test:Config {
+    groups: ["sftp-connection", "negative"]
+}
+function testSftpConnectWithEmptyKeyPath() {
+    ftp:Client|ftp:Error result = new ({
+        protocol: ftp:SFTP,
+        host: commons:FTP_HOST,
+        port: commons:SFTP_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            privateKey: {path: "", password: "changeit"}
+        }
+    });
+    // Invariant: rejected at client init as a config error, not smuggled into VFS
+    // where it turns into a cryptic IdentityInfo failure. Exact wording is not
+    // part of the contract.
+    test:assertTrue(result is ftp:InvalidConfigError,
+            "Expected InvalidConfigError for empty SFTP key path");
+}
+
+// A key path pointing at a directory must be rejected up front.
+@test:Config {
+    groups: ["sftp-connection", "negative"]
+}
+function testSftpConnectWithKeyPathIsDirectory() {
+    ftp:Client|ftp:Error result = new ({
+        protocol: ftp:SFTP,
+        host: commons:FTP_HOST,
+        port: commons:SFTP_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            privateKey: {path: commons:RESOURCES_PATH, password: "changeit"}
+        }
+    });
+    test:assertTrue(result is ftp:Error,
+            "Expected error for SFTP key path that is a directory");
+    if result is ftp:Error {
+        // Invariant: the configured path is named so the user can see what they
+        // pointed at. Exact wording (directory / not a regular file / etc.) is
+        // not frozen.
+        test:assertTrue(result.message().includes(commons:RESOURCES_PATH),
+                "Error should name the configured key path: " + result.message());
+    }
+}
+
+// A public-key file passed where a private key is expected: passes the
+// regular-file pre-validation and fails inside JSch. The rewrapped message
+// names the path and guides the user.
+@test:Config {
+    groups: ["sftp-connection", "negative"]
+}
+function testSftpConnectWithPublicKeyAsPrivate() {
+    ftp:Client|ftp:Error result = new ({
+        protocol: ftp:SFTP,
+        host: commons:FTP_HOST,
+        port: commons:SFTP_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            privateKey: {path: commons:RESOURCES_PATH + "/sftp.public.key"}
+        }
+    });
+    test:assertTrue(result is ftp:Error,
+            "Expected error for public-key passed as private key");
+    if result is ftp:Error {
+        // Invariants (not exact phrasing):
+        //   1. The configured path is named.
+        //   2. JSch's "IdentityInfo@<hash>" toString does not leak
+        //      (ballerina-library#8760, #8763).
+        test:assertTrue(result.message().includes("sftp.public.key"),
+                "Error should name the configured key path: " + result.message());
+        test:assertFalse(result.message().includes("IdentityInfo@"),
+                "Error must not leak the JSch IdentityInfo object identity: "
+                + result.message());
     }
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Apply the content method's `afterError` action when content binding fails before the handler is invoked](https://github.com/wso2/product-integrator/issues/1161)
 - [Validate `fileAgeFilter` values at listener startup; reject negative `minAge`/`maxAge` and `minAge` greater than `maxAge`](https://github.com/wso2/product-integrator/issues/1151)
 - [Enforce hostname verification and JDK cacerts trust chain for FTPS connections by default](https://github.com/wso2/product-integrator/issues/829)
+- [Improve error messages for SFTP private-key load failures — surface the configured path and a useful hint instead of the Java object identity](https://github.com/ballerina-platform/ballerina-library/issues/8760)
+- [Suppress JSch auto-discovery of default SSH identity files when no privateKey is configured](https://github.com/ballerina-platform/ballerina-library/issues/6769)
+- [Reject empty-string `path` in `privateKey` / `secureSocket.key` / `secureSocket.cert` at client init, matching the listener-side behaviour](https://github.com/ballerina-platform/ballerina-library/issues/8762)
+- [Disambiguate SFTP key-load failures (wrong/missing passphrase, malformed key) from generic connect failures](https://github.com/ballerina-platform/ballerina-library/issues/8763)
+- [Wrap cryptic JVM keystore errors: detect PEM-as-keystore and guard against the literal "null" that appeared when the underlying exception had no message](https://github.com/wso2/product-integrator/issues/831)
 
 ### Changed
 
@@ -33,8 +38,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Fix SFTP listener blocking on shutdown due to exec channel probe on restricted servers](https://github.com/ballerina-platform/ballerina-library/issues/8708)
-
-### Changed
 
 ## [2.17.1] - 2026-02-26
 

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-jdk14', version: "${slf4jVersion}"
     implementation group: 'org.apache.commons', name: 'commons-vfs2', version: "${commonsVfsVersion}"
     implementation group: 'commons-net', name: 'commons-net', version: "${commonsNetVersion}"
+    implementation group: 'com.jcraft', name: 'jsch', version: "${jschVersion}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${commonsLang3Version}"
     implementation group: 'commons-io', name: 'commons-io', version: "${commonsIoVersion}"
     implementation group: 'io.ballerina.lib', name: 'data.jsondata-native', version: "${stdlibDataJsonDataVersion}"

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -257,12 +257,15 @@ public class FtpClient {
             return validationError;
         }
         
-        configurePrivateKey(auth, ftpConfig);
-        
-        if (auth.getMapValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_SECURE_SOCKET)) != null 
+        Object pkError = configurePrivateKey(auth, ftpConfig);
+        if (pkError != null) {
+            return pkError;
+        }
+
+        if (auth.getMapValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_SECURE_SOCKET)) != null
                 && protocol.equals(FtpConstants.SCHEME_FTPS)) {
             Object ftpsError = configureFtpsSecureSocket(
-                    auth.getMapValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_SECURE_SOCKET)), 
+                    auth.getMapValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_SECURE_SOCKET)),
                     ftpConfig);
             if (ftpsError != null) {
                 return ftpsError;
@@ -294,23 +297,28 @@ public class FtpClient {
         return null;
     }
 
-    private static void configurePrivateKey(BMap auth, Map<String, Object> ftpConfig) {
+    private static Object configurePrivateKey(BMap auth, Map<String, Object> ftpConfig) {
         final BMap privateKey = auth.getMapValue(StringUtils.fromString(
                 FtpConstants.ENDPOINT_CONFIG_PRIVATE_KEY));
-        
+
         if (privateKey == null) {
-            return;
+            return null;
         }
-        
+
         final BString privateKeyPath = privateKey.getStringValue(StringUtils.fromString(
                 FtpConstants.ENDPOINT_CONFIG_KEY_PATH));
+        if (privateKeyPath == null || privateKeyPath.getValue().isBlank()) {
+            return FtpUtil.createError("privateKey path cannot be empty.",
+                    InvalidConfigError.errorType());
+        }
         ftpConfig.put(FtpConstants.IDENTITY, privateKeyPath.getValue());
-        
+
         final BString privateKeyPassword = privateKey.getStringValue(StringUtils.fromString(
                 FtpConstants.ENDPOINT_CONFIG_PASS_KEY));
         if (privateKeyPassword != null && !privateKeyPassword.getValue().isEmpty()) {
             ftpConfig.put(FtpConstants.IDENTITY_PASS_PHRASE, privateKeyPassword.getValue());
         }
+        return null;
     }
 
     private static void applyDefaultFtpConfig(BMap<Object, Object> config, Map<String, Object> ftpConfig) {
@@ -390,15 +398,23 @@ public class FtpClient {
                 StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_VERIFY_HOST_NAME));
         ftpConfig.put(FtpConstants.ENDPOINT_CONFIG_VERIFY_HOST_NAME, verifyHostName);
 
-        FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_KEY,
+        String keyStorePath = FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_KEY,
                 FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PATH,
                 FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PASSWORD,
                 ftpConfig);
+        if (keyStorePath != null && keyStorePath.isBlank()) {
+            return FtpUtil.createError("secureSocket.key.path cannot be empty.",
+                    InvalidConfigError.errorType());
+        }
 
-        FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_TRUSTSTORE,
+        String trustStorePath = FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_TRUSTSTORE,
                 FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PATH,
                 FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PASSWORD,
                 ftpConfig);
+        if (trustStorePath != null && trustStorePath.isBlank()) {
+            return FtpUtil.createError("secureSocket.cert.path cannot be empty.",
+                    InvalidConfigError.errorType());
+        }
 
         return null;
     }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
@@ -696,17 +696,17 @@ public class FtpListenerHelper {
                 FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PASSWORD, 
                 params);
         
-        if (keyStorePath != null && keyStorePath.isEmpty()) {
+        if (keyStorePath != null && keyStorePath.isBlank()) {
             throw new BallerinaFtpException("Failed to load FTPS Server Keystore: Path cannot be empty");
         }
 
-        String trustStorePath = FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_TRUSTSTORE, 
-                FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PATH, 
-                FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PASSWORD, 
+        String trustStorePath = FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_TRUSTSTORE,
+                FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PATH,
+                FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PASSWORD,
                 params);
-        
-        if (trustStorePath != null && trustStorePath.isEmpty()) {
-            params.remove(FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PATH);
+
+        if (trustStorePath != null && trustStorePath.isBlank()) {
+            throw new BallerinaFtpException("Failed to load FTPS Server Truststore: Path cannot be empty");
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/ftp/transport/client/connector/contractimpl/VfsClientConnectorImpl.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/transport/client/connector/contractimpl/VfsClientConnectorImpl.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.stdlib.ftp.transport.client.connector.contractimpl;
 
+import com.jcraft.jsch.JSchException;
 import io.ballerina.stdlib.ftp.exception.BallerinaFtpException;
 import io.ballerina.stdlib.ftp.exception.FtpConnectionException;
 import io.ballerina.stdlib.ftp.exception.FtpFileAlreadyExistsException;
@@ -82,8 +83,34 @@ public class VfsClientConnectorImpl implements VfsClientConnector {
             path = fsManager.resolveFile(fileURI, opts);
         } catch (FileSystemException e) {
             String safeUri = maskUrlPassword(fileURI);
-            String rootCauseMessage = (e.getCause() != null && e.getCause().getMessage() != null)
-                    ? e.getCause().getMessage() : e.getMessage();
+            Throwable cause = e.getCause();
+            String rootCauseMessage = (cause != null && cause.getMessage() != null)
+                    ? cause.getMessage() : e.getMessage();
+
+            // Apache Commons VFS surfaces SFTP key-load failures as a nested
+            // FileSystemException wrapping a JSchException, with a message of the
+            // form "Could not load private key from "IdentityInfo@<hash>"" (the
+            // configured path is lost). Walk the cause chain and substitute a
+            // clear message that names the path and the reason. Covers explicit
+            // bad paths, wrong/missing passphrase, malformed keys, and the
+            // auto-loaded ~/.ssh/id_rsa case when no privateKey is set.
+            JSchException jschCause = findCause(e, JSchException.class);
+            if (jschCause != null) {
+                Object identity = connectorConfig.get(FtpConstants.IDENTITY);
+                String keyPath = identity != null ? identity.toString() : "<auto-discovered>";
+                // Null-guard the JSchException message so the user-facing string never
+                // concatenates a literal "null" — same class of bug this PR addresses
+                // elsewhere.
+                String jschReason = jschCause.getMessage();
+                if (jschReason == null || jschReason.isBlank()) {
+                    jschReason = "Unable to load or use the private key.";
+                }
+                rootCauseMessage = "SFTP key authentication failed for private key \""
+                        + keyPath + "\". " + jschReason
+                        + " Verify the key file is a valid private key and the passphrase"
+                        + " (if any) is correct.";
+            }
+
             String errorMessage = "Error while connecting to the FTP server with URL: "
                     + (safeUri != null ? safeUri : "") + ". " + rootCauseMessage;
 
@@ -91,11 +118,22 @@ public class VfsClientConnectorImpl implements VfsClientConnector {
             String fullMessage = FtpErrorCodeAnalyzer.getFullErrorMessage(e);
             if (FtpErrorCodeAnalyzer.isServiceUnavailable(fullMessage)) {
                 int ftpCode = FtpErrorCodeAnalyzer.extractFtpCodeFromException(e).orElse(0);
-                throw new FtpServiceUnavailableException(errorMessage, ftpCode, e.getCause());
+                throw new FtpServiceUnavailableException(errorMessage, ftpCode, cause);
             }
 
-            throw new FtpConnectionException(errorMessage, e.getCause());
+            throw new FtpConnectionException(errorMessage, cause);
         }
+    }
+
+    private static <T extends Throwable> T findCause(Throwable start, Class<T> target) {
+        Throwable t = start;
+        while (t != null) {
+            if (target.isInstance(t)) {
+                return target.cast(t);
+            }
+            t = t.getCause();
+        }
+        return null;
     }
 
     public void addListener(RemoteFileSystemListener listener) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.stdlib.ftp.transport.server.util;
 
+import io.ballerina.stdlib.ftp.exception.BallerinaFtpException;
 import io.ballerina.stdlib.ftp.exception.RemoteFileSystemConnectorException;
 import io.ballerina.stdlib.ftp.transport.ftps.HostnameVerifyingFtpsConfigHelper;
 import io.ballerina.stdlib.ftp.util.ExcludeCoverageFromGeneratedReport;
@@ -31,6 +32,7 @@ import org.apache.commons.vfs2.provider.ftps.FtpsDataChannelProtectionLevel;
 import org.apache.commons.vfs2.provider.ftps.FtpsFileSystemConfigBuilder;
 import org.apache.commons.vfs2.provider.ftps.FtpsMode;
 import org.apache.commons.vfs2.provider.sftp.IdentityInfo;
+import org.apache.commons.vfs2.provider.sftp.IdentityProvider;
 import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -321,15 +323,34 @@ public final class FileTransportUtils {
         configBuilder.setUserDirIsRoot(opts, userDirIsRoot);
         Object identityObj = options.get(FtpConstants.IDENTITY);
         if (identityObj != null) {
+            String identityPath = identityObj.toString();
+            try {
+                FtpUtil.validateRegularFile("SFTP private key", identityPath);
+            } catch (BallerinaFtpException e) {
+                // Surface the original (always non-null) validation message. Guard against
+                // null just in case a future subclass omits one — callers should never see
+                // the literal "null".
+                String msg = e.getMessage();
+                if (msg == null || msg.isBlank()) {
+                    msg = "SFTP private key file is not usable: " + identityPath;
+                }
+                throw new RemoteFileSystemConnectorException(msg, e);
+            }
             IdentityInfo identityInfo;
             Object passPhraseObj = options.get(IDENTITY_PASS_PHRASE);
             if (passPhraseObj != null) {
-                identityInfo = new IdentityInfo(new File(identityObj.toString()),
-                        passPhraseObj.toString().getBytes());
+                identityInfo = new IdentityInfo(new File(identityPath),
+                        passPhraseObj.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8));
             } else {
-                identityInfo = new IdentityInfo(new File(identityObj.toString()));
+                identityInfo = new IdentityInfo(new File(identityPath));
             }
             configBuilder.setIdentityInfo(opts, identityInfo);
+        } else {
+            // No privateKey configured. Suppress JSch's auto-discovery of ~/.ssh/id_rsa
+            // so an unreadable / wrong-format default key on the host doesn't poison
+            // password-only auth flows (see ballerina-library#6769, #8760, and
+            // wso2/product-integrator#1132).
+            configBuilder.setIdentityProvider(opts, new IdentityProvider[0]);
         }
         // Prevent JSch from probing server capabilities via exec channel (e.g. "id -u").
         // Servers that expose only SFTP/SCP subsystems reject exec commands, which can stall shutdown.

--- a/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpUtil.java
@@ -723,35 +723,97 @@ public class FtpUtil {
     }
 
     /**
+     * Verifies that {@code path} points at a regular, non-empty, readable file.
+     * Used to surface a clear error before VFS or KeyStore loaders raise cryptic
+     * downstream exceptions for missing/empty/directory/unreadable inputs.
+     * Rejects non-regular files (device nodes, pipes, symlinks to directories).
+     */
+    public static void validateRegularFile(String purpose, String path) throws BallerinaFtpException {
+        if (path == null || path.isBlank()) {
+            throw new BallerinaFtpException(purpose + " path cannot be empty.");
+        }
+        File f = new File(path);
+        if (!f.exists()) {
+            throw new BallerinaFtpException(purpose + " file does not exist: " + path);
+        }
+        if (f.isDirectory()) {
+            throw new BallerinaFtpException(purpose + " path is a directory, expected a file: " + path);
+        }
+        if (!f.isFile()) {
+            throw new BallerinaFtpException(purpose + " path is not a regular file: " + path);
+        }
+        if (!f.canRead()) {
+            throw new BallerinaFtpException(purpose + " file is not readable: " + path);
+        }
+        if (f.length() == 0) {
+            throw new BallerinaFtpException(purpose + " file is empty: " + path);
+        }
+    }
+
+    /**
      * Loads a Java KeyStore from a file path and password.
-     * 
-     * @param path The file path to the KeyStore
+     *
+     * <p>A {@code null} path is treated as "no keystore configured" and returns
+     * {@code null} so callers can initialize a TrustManagerFactory with JVM
+     * default trust. Any non-null path — including the empty string — is run
+     * through {@link #validateRegularFile(String, String)} so empty / missing /
+     * directory / unreadable / zero-byte inputs fail up front instead of
+     * bypassing validation.</p>
+     *
+     * @param path The file path to the KeyStore, or {@code null}
      * @param password The password for the KeyStore
-     * @return The loaded java.security.KeyStore object
+     * @return The loaded {@link KeyStore}, or {@code null} if {@code path} is null
      * @throws BallerinaFtpException If loading fails
      */
     public static KeyStore loadKeyStore(String path, String password) throws BallerinaFtpException {
-        if (path == null || path.isEmpty()) {
+        if (path == null) {
             return null;
         }
         try {
-            // JKS extension checking
+            validateRegularFile("KeyStore", path);
+        } catch (BallerinaFtpException e) {
+            // Re-wrap to preserve the "Failed to load KeyStore from path: ..." prefix
+            // expected by existing callers and tests.
+            throw new BallerinaFtpException("Failed to load KeyStore from path: " + path
+                    + ". " + e.getMessage(), e);
+        }
+        try {
             String type = KeyStore.getDefaultType();
-            if (path.toLowerCase().endsWith(".jks")) {
+            String lower = path.toLowerCase(java.util.Locale.ROOT);
+            if (lower.endsWith(".jks")) {
                 type = "JKS";
-            } else if (path.toLowerCase().endsWith(".p12") || path.toLowerCase().endsWith(".pfx")) {
+            } else if (lower.endsWith(".p12") || lower.endsWith(".pfx")) {
                 type = "PKCS12";
+            }
+            // Sniff the first 16 bytes to catch the common "user passed a PEM" case
+            // before the JDK throws "toDerInputStream rejects tag type 45".
+            byte[] header = new byte[16];
+            try (FileInputStream sniff = new FileInputStream(new File(path))) {
+                int read = sniff.read(header);
+                String headerText = read > 0
+                        ? new String(header, 0, read, java.nio.charset.StandardCharsets.US_ASCII)
+                        : "";
+                if (read >= 11 && headerText.startsWith("-----BEGIN ")) {
+                    throw new BallerinaFtpException("Failed to load KeyStore from path: " + path
+                            + ". File looks like a PEM (starts with '-----BEGIN '); "
+                            + "expected a " + type + " keystore.");
+                }
             }
 
             KeyStore keyStore = KeyStore.getInstance(type);
             char[] passChars = (password != null) ? password.toCharArray() : null;
-            
             try (FileInputStream fis = new FileInputStream(new File(path))) {
                 keyStore.load(fis, passChars);
             }
             return keyStore;
+        } catch (BallerinaFtpException e) {
+            throw e;
         } catch (Exception e) {
-            throw new BallerinaFtpException("Failed to load KeyStore from path: " + path + ". " + e.getMessage(), e);
+            String detail = e.getMessage();
+            if (detail == null || detail.isBlank()) {
+                detail = e.getClass().getSimpleName() + " (file may be corrupted or not a valid keystore)";
+            }
+            throw new BallerinaFtpException("Failed to load KeyStore from path: " + path + ". " + detail, e);
         }
     }
 

--- a/native/src/main/java/module-info.java
+++ b/native/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module io.ballerina.stdlib.ftp {
     requires java.logging;
     requires org.apache.commons.vfs2;
     requires org.apache.commons.net;
+    requires jsch;
     requires io.ballerina.lib.data;
     requires io.ballerina.lib.data.xmldata;
     requires io.ballerina.lib.data.csvdata;


### PR DESCRIPTION
## Summary

Cleans up the surface error story for the FTPS and SFTP key/cert handling paths, which today leaks Java internals (e.g. `IdentityInfo@<hash>`, `toDerInputStream rejects tag type 45`, trailing `null`) and silently accepts invalid configs.

### SFTP
- Pre-validate the configured `privateKey.path` (exists, regular file, readable, non-empty) before handing it to Apache Commons VFS / JSch — avoids the cryptic `Could not load private key from "IdentityInfo@<hash>"` for missing/empty/directory/unreadable inputs.
- When no `privateKey` is configured, install an empty `IdentityProvider` array so JSch does not auto-discover `~/.ssh/id_rsa`. An unreadable / wrong-format default key on the host no longer poisons password-only auth flows. (Closes ballerina-platform/ballerina-library#6769, wso2/product-integrator#1132.)
- In `VfsClientConnectorImpl`, walk the cause chain looking for a `JSchException` and substitute a clear message that names the configured path and includes the underlying reason. Disambiguates wrong/missing passphrase, malformed keys, public-key-as-private, etc. from generic connect failures.
- Reject empty-string `privateKey.path` at client init.

### FTPS
- Reject empty-string `secureSocket.key.path` / `secureSocket.cert.path` at client init to match the listener-side validation.
- Listener side: throw on empty truststore path instead of silently stripping it (mirrors the keystore handling on the same code path).
- KeyStore loader: pre-validate the file the same way; sniff the first bytes to detect a PEM passed as a keystore and surface a friendly error instead of `toDerInputStream rejects tag type 45`; null-guard the wrapped exception so the message no longer ends in `null`. (Addresses wso2/product-integrator#831.)

### Tests
- Update `testSecureConnectWithInvalidKeyPath` to assert the new clear message that includes the configured path.
- Add `testSecureConnectWithEmptyKeyPath`, `testSecureConnectWithKeyPathIsDirectory`, `testSecureConnectWithPublicKeyAsPrivate`.
- Add `testFtpsClientConnectWithEmptyKeystorePath`, `testFtpsClientConnectWithEmptyTruststorePath`, `testFtpsClientConnectWithEmptyKeystoreFile`, `testFtpsClientConnectWithPemAsKeystore`.

### Build
- Add explicit `com.jcraft:jsch` dependency in `native/build.gradle` and `requires jsch;` in `module-info.java` so we can reference the `JSchException` type directly (it was already a transitive dep via Apache Commons VFS).

## Closes
- ballerina-platform/ballerina-library#8760 — SFTP `IdentityInfo@<hash>` leak for explicit bad paths
- ballerina-platform/ballerina-library#8762 — Empty-string path silently accepted on client side
- ballerina-platform/ballerina-library#8763 — Wrong/missing SFTP passphrase aborts with no signal
- ballerina-platform/ballerina-library#6769 — SFTP fails on macOS when no `privateKey` is configured (default `id_rsa` auto-load)
- wso2/product-integrator#1132 — SFTP listener fails when default SSH identity files exist
- wso2/product-integrator#831 — Literal `null` in FTPS keystore-load errors

## Test plan

- [x] All 8 new + 1 updated targeted tests pass locally against the project's mock FTP/FTPS/SFTP server.
- [ ] Full build + test suite passes in CI.
- [ ] No regression in existing `secure_*_test.bal` suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request improves input validation and error reporting for FTPS and SFTP key/certificate handling to provide clearer diagnostics, reject invalid or empty configurations earlier, and avoid leaking Java internals.

### Key Changes

- Input validation
  - SFTP: Pre-validate configured privateKey.path (exists, regular file, readable, non-empty) and reject empty-string privateKey.path at client init.
  - FTPS: Reject empty-string secureSocket.key.path and secureSocket.cert.path at client init; listener now throws on empty truststore path instead of silently removing it.
  - New utility FtpUtil.validateRegularFile to centralize file validation for keystores/certificates.

- Error reporting
  - SFTP: Traverse exception cause chain to detect JSch exceptions and replace low-level messages with a clear, path-aware message describing the configured identity and the underlying reason.
  - Keystore loader: Pre-validate keystore files, detect PEM files passed as keystores and surface friendly messages, and avoid producing null/blank trailing messages when wrapped exceptions lack messages.

- Behavior clarity
  - SFTP: When no private key is configured, explicitly install an empty IdentityProvider array to prevent auto-discovery of user SSH identities.

- Build and tests
  - Add explicit com.jcraft:jsch dependency and module requires to support targeted exception handling.
  - Add and update targeted tests covering empty/invalid key paths, directory-as-key, public-key-as-private, empty keystore/truststore, and PEM-as-keystore scenarios.

### Impact

Users will receive faster, more actionable error messages during client initialization and connection attempts, invalid configurations will be rejected earlier, and user-facing messages will no longer expose Java internal object identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->