### PR TITLE
Validate FTPS server certificates by default; add verifyServerCert opt-out

### DIFF
--- a/ballerina-tests/ftps-connection-tests/tests/ftps_connection_test.bal
+++ b/ballerina-tests/ftps-connection-tests/tests/ftps_connection_test.bal
@@ -316,6 +316,64 @@ function testFtpsConnectWithWrongKeystorePassword() {
 }
 
 // =============================================================================
+// Server certificate validation (verifyServerCert)
+// =============================================================================
+
+// With verifyServerCert default (true) and no `cert` configured, the JVM default
+// cacerts is used. It does not trust the mock server's self-signed cert, so the
+// TLS handshake must fail. This is the secure default that replaces the previous
+// silent accept-all behaviour.
+@test:Config {
+    groups: ["ftps-connection", "negative", "tls"]
+}
+function testFtpsConnectNoCertRejectsUntrustedServer() {
+    ftp:Client|ftp:Error result = new ({
+        protocol: ftp:FTPS,
+        host: commons:FTP_HOST,
+        port: commons:FTPS_EXPLICIT_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            secureSocket: {
+                key: {path: commons:KEYSTORE_PATH, password: "changeit"},
+                mode: ftp:EXPLICIT
+            }
+        }
+    });
+    test:assertTrue(result is ftp:Error,
+            "Expected untrusted self-signed server cert to be rejected by default");
+    if result is ftp:Error {
+        test:assertTrue(result.message().startsWith("Error while connecting to the FTP server"),
+                "Unexpected error message: " + result.message());
+    }
+}
+
+// Explicit opt-out via verifyServerCert=false installs an accept-all
+// TrustManager. Intended for development only; mirrors
+// http:SecureSocket.verifyHostname=false.
+@test:Config {
+    groups: ["ftps-connection", "tls"]
+}
+function testFtpsConnectVerifyServerCertFalseAcceptsUntrustedServer() returns error? {
+    ftp:Client ftpsClient = check new ({
+        protocol: ftp:FTPS,
+        host: commons:FTP_HOST,
+        port: commons:FTPS_EXPLICIT_PORT,
+        auth: {
+            credentials: {username: commons:FTP_USERNAME, password: commons:FTP_PASSWORD},
+            secureSocket: {
+                key: {path: commons:KEYSTORE_PATH, password: "changeit"},
+                verifyServerCert: false,
+                mode: ftp:EXPLICIT
+            }
+        }
+    });
+    boolean|ftp:Error result = ftpsClient->exists(commons:FTPS_ROOT);
+    test:assertFalse(result is ftp:Error,
+            "Expected FTPS connection to succeed when verifyServerCert=false");
+    check ftpsClient->close();
+}
+
+// =============================================================================
 // Negative: unreachable server
 // =============================================================================
 

--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -64,6 +64,12 @@ public type SecureSocket record {|
     crypto:KeyStore key?;
     # Certificate configuration for server certificate validation
     crypto:TrustStore cert?;
+    # Whether the server's certificate is validated against the configured truststore
+    # (or the JVM default `cacerts` when no `cert` is provided). Setting this to
+    # `false` accepts any server certificate and is **insecure** — only use it for
+    # development against self-signed servers when configuring a proper truststore
+    # is not feasible.
+    boolean verifyServerCert = true;
     # FTPS connection mode.
     FtpsMode mode = EXPLICIT;
     # Data channel protection level. Controls encryption of the data channel used for file transfers.

--- a/changelog.md
+++ b/changelog.md
@@ -5,14 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## unreleased
 
+### Added
+
+- Add `secureSocket.verifyServerCert` flag (default `true`) to `ftp:SecureSocket` for opting out of FTPS server-certificate validation in development setups. See the breaking-change note below.
+
+### Changed
+
+- **BREAKING:** [FTPS now validates server certificates by default](https://github.com/ballerina-platform/ballerina-library/issues/8761). Previously, `secureSocket` configurations that omitted `cert` silently accepted any server certificate. Connections that were succeeding against self-signed or private-CA servers without a configured truststore will now fail with a PKIX validation error. To restore the old behavior, either configure `cert` properly, add the server certificate to the JVM `cacerts`, or set `verifyServerCert: false` (insecure — for dev only).
+- Restructure the Ballerina test suite into per-protocol and per-feature test projects under `ballerina-tests/`, with an isolated advisory-mode project for timing-sensitive (file-age/file-dependency) tests
+
 ### Fixed
 
 - [Apply the content method's `afterError` action when content binding fails before the handler is invoked](https://github.com/wso2/product-integrator/issues/1161)
 - [Validate `fileAgeFilter` values at listener startup; reject negative `minAge`/`maxAge` and `minAge` greater than `maxAge`](https://github.com/wso2/product-integrator/issues/1151)
-
-### Changed
-
-- Restructure the Ballerina test suite into per-protocol and per-feature test projects under `ballerina-tests/`, with an isolated advisory-mode project for timing-sensitive (file-age/file-dependency) tests
 
 ## [2.18.1] - 2026-03-26
 
@@ -28,8 +33,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - [Fix SFTP listener blocking on shutdown due to exec channel probe on restricted servers](https://github.com/ballerina-platform/ballerina-library/issues/8708)
-
-### Changed
 
 ## [2.17.1] - 2026-02-26
 

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -385,15 +385,16 @@ public class FtpClient {
     private static Object configureFtpsSecureSocket(BMap secureSocket, Map<String, Object> ftpConfig) {
         FtpUtil.configureFtpsMode(secureSocket, ftpConfig);
         FtpUtil.configureFtpsDataChannelProtection(secureSocket, ftpConfig);
-        
-        FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_KEY, 
-                FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PATH, 
-                FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PASSWORD, 
+        FtpUtil.configureVerifyServerCert(secureSocket, ftpConfig);
+
+        FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_KEY,
+                FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PATH,
+                FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PASSWORD,
                 ftpConfig);
 
-        FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_TRUSTSTORE, 
-                FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PATH, 
-                FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PASSWORD, 
+        FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_TRUSTSTORE,
+                FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PATH,
+                FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PASSWORD,
                 ftpConfig);
 
         return null;

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
@@ -686,8 +686,9 @@ public class FtpListenerHelper {
             throws BallerinaFtpException {
         FtpUtil.configureFtpsMode(secureSocket, params);
         FtpUtil.configureFtpsDataChannelProtection(secureSocket, params);
-        
-        String keyStorePath = FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_KEY, 
+        FtpUtil.configureVerifyServerCert(secureSocket, params);
+
+        String keyStorePath = FtpUtil.extractAndConfigureStore(secureSocket, FtpConstants.SECURE_SOCKET_KEY,
                 FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PATH, 
                 FtpConstants.ENDPOINT_CONFIG_KEYSTORE_PASSWORD, 
                 params);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
@@ -68,15 +68,26 @@ public final class FileTransportUtils {
 
     /**
      * INSECURE trust manager that accepts any certificate. Installed only when
-     * the user explicitly sets {@code secureSocket.verifyServerCert = false}.
+     * the user explicitly sets {@code secureSocket.verifyServerCert = false} to
+     * preserve legacy behaviour for development setups that cannot use a proper
+     * truststore. A warning log is emitted on every connector init that selects
+     * this path.
+     *
+     * <p>The empty checkClientTrusted / checkServerTrusted overrides are the
+     * documented way to opt out of server certificate validation; Sonar rule
+     * java:S4830 is suppressed intentionally because the alternative is to not
+     * offer the opt-out at all.</p>
      */
+    @SuppressWarnings("java:S4830") // Opt-in insecure trust manager behind verifyServerCert=false.
     private static final X509TrustManager ACCEPT_ALL_TRUST_MANAGER = new X509TrustManager() {
         @Override
+        @SuppressWarnings("java:S4830")
         public void checkClientTrusted(X509Certificate[] chain, String authType) {
             // Intentional no-op: insecure mode.
         }
 
         @Override
+        @SuppressWarnings("java:S4830")
         public void checkServerTrusted(X509Certificate[] chain, String authType) {
             // Intentional no-op: insecure mode.
         }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.security.KeyStore;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.Map;
@@ -45,6 +46,7 @@ import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ENDPOINT_CONFIG_PREFERRED_METHODS;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.IDENTITY_PASS_PHRASE;
@@ -63,6 +65,27 @@ public final class FileTransportUtils {
 
     private static final Pattern URL_PATTERN = Pattern.compile("^[a-z][a-z0-9+.-]*://", Pattern.CASE_INSENSITIVE);
     private static final Pattern USERINFO_WITH_PASSWORD = Pattern.compile("://([^/@:]+):([^/@]*)@");
+
+    /**
+     * INSECURE trust manager that accepts any certificate. Installed only when
+     * the user explicitly sets {@code secureSocket.verifyServerCert = false}.
+     */
+    private static final X509TrustManager ACCEPT_ALL_TRUST_MANAGER = new X509TrustManager() {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+            // Intentional no-op: insecure mode.
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            // Intentional no-op: insecure mode.
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    };
 
     /**
      * A utility method for setting the relevant configurations for the file system in question.
@@ -243,26 +266,45 @@ public final class FileTransportUtils {
                 }
             }
 
-            // 2. Configure TrustStore (Server Validation)
-            Object truststorePathObj = options.get(FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PATH);
-            if (truststorePathObj != null) {
-                String trustStorePath = (String) truststorePathObj;
-                Object passwordObj = options.get(FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PASSWORD);
-                String password = (passwordObj != null) ? passwordObj.toString() : null;
+            // 2. Configure TrustStore (Server Validation).
+            //
+            // Always install a TrustManager so server certificate validation cannot be
+            // silently skipped. When the user opts out via verifyServerCert=false, an
+            // accept-all manager is installed (insecure — for dev only). When no
+            // truststore is configured, the JVM default cacerts is used by passing
+            // null to TrustManagerFactory.init.
+            boolean verifyServerCert = true;
+            Object verifyServerCertObj = options.get(FtpConstants.ENDPOINT_CONFIG_VERIFY_SERVER_CERT);
+            if (verifyServerCertObj != null) {
+                verifyServerCert = Boolean.parseBoolean(verifyServerCertObj.toString());
+            }
 
-                // Load TrustStore here
-                KeyStore trustStore = FtpUtil.loadKeyStore(trustStorePath, password);
+            if (!verifyServerCert) {
+                log.warn("FTPS configured with verifyServerCert=false. Server certificate "
+                        + "validation is disabled. This is INSECURE — any server certificate "
+                        + "will be accepted, including expired or untrusted ones.");
+                ftpsConfigBuilder.setTrustManager(opts, ACCEPT_ALL_TRUST_MANAGER);
+            } else {
+                KeyStore trustStore = null;
+                Object truststorePathObj = options.get(FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PATH);
+                if (truststorePathObj != null) {
+                    String trustStorePath = (String) truststorePathObj;
+                    Object passwordObj = options.get(FtpConstants.ENDPOINT_CONFIG_TRUSTSTORE_PASSWORD);
+                    String password = (passwordObj != null) ? passwordObj.toString() : null;
+                    trustStore = FtpUtil.loadKeyStore(trustStorePath, password);
+                }
 
-                // Init TrustManagerFactory
-                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                TrustManagerFactory tmf = TrustManagerFactory.getInstance(
+                        TrustManagerFactory.getDefaultAlgorithm());
+                // null trustStore = JVM default cacerts. Without this we'd silently
+                // accept any server cert, defeating TLS.
                 tmf.init(trustStore);
                 TrustManager[] trustManagers = tmf.getTrustManagers();
-
                 if (trustManagers != null && trustManagers.length > 0) {
                     ftpsConfigBuilder.setTrustManager(opts, trustManagers[0]);
                 } else {
-                    log.warn("FTPS configured with TrustStore path {} but no TrustManagers were found.",
-                            trustStorePath);
+                    log.warn("FTPS TrustManagerFactory returned no TrustManagers; "
+                            + "server certificate validation will fall back to VFS defaults.");
                 }
             }
         } catch (Exception e) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpConstants.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpConstants.java
@@ -85,10 +85,12 @@ public class FtpConstants {
     public static final String ENDPOINT_CONFIG_KEYSTORE_PASSWORD = "keystorePassword";
     public static final String ENDPOINT_CONFIG_TRUSTSTORE_PATH = "truststorePath";
     public static final String ENDPOINT_CONFIG_TRUSTSTORE_PASSWORD = "truststorePassword";
+    public static final String ENDPOINT_CONFIG_VERIFY_SERVER_CERT = "verifyServerCert";
 
     // Keys for extracting data from Ballerina Records
     public static final String SECURE_SOCKET_KEY = "key";
     public static final String SECURE_SOCKET_TRUSTSTORE = "cert";
+    public static final String SECURE_SOCKET_VERIFY_SERVER_CERT = "verifyServerCert";
     public static final String KEYSTORE_PATH_KEY = "path";
     public static final String KEYSTORE_PASSWORD_KEY = "password";
 

--- a/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/util/FtpUtil.java
@@ -307,6 +307,22 @@ public class FtpUtil {
         return path;
     }
 
+    /**
+     * Reads the optional `verifyServerCert` boolean from the secureSocket record
+     * and stores it as a String in the config map. Defaults to {@code true} when
+     * the field is absent (the field carries a default in the Ballerina type, but
+     * we guard against null here to keep the Java side robust against older
+     * Ballerina records that omit it).
+     */
+    public static void configureVerifyServerCert(BMap secureSocket, Map<String, Object> config) {
+        boolean verify = true;
+        if (secureSocket.containsKey(StringUtils.fromString(FtpConstants.SECURE_SOCKET_VERIFY_SERVER_CERT))) {
+            verify = secureSocket.getBooleanValue(
+                    StringUtils.fromString(FtpConstants.SECURE_SOCKET_VERIFY_SERVER_CERT));
+        }
+        config.put(FtpConstants.ENDPOINT_CONFIG_VERIFY_SERVER_CERT, String.valueOf(verify));
+    }
+
     public static String createUrl(BObject clientConnector, String filePath) throws BallerinaFtpException {
         String username = (String) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_USERNAME);
         String password = null;


### PR DESCRIPTION
## Summary

The FTPS provider used to skip installing a `TrustManager` when `secureSocket.cert` was not configured. Apache Commons VFS then fell back to a permissive default and any server certificate was silently accepted. Combined with the missing hostname verification (tracked separately in wso2/product-integrator#829), this meant an attacker presenting any certificate could MITM FTPS connections.

## What changed

- **Always install a `TrustManager` in `configureFtpsSslCertificates`.** When no truststore is configured, initialize the factory with `null` so the JVM default `cacerts` is used. Untrusted server certs (self-signed or signed by a CA not in `cacerts`) now fail the TLS handshake with a PKIX error.
- **Add `boolean verifyServerCert = true` on `ftp:SecureSocket`.** Setting it to `false` installs an accept-all `X509TrustManager` and emits a one-time `log.warn` during connector init. Preserves the old behaviour as an explicit, documented opt-out for dev setups that cannot use a proper truststore. Mirrors `http:SecureSocket.verifyHostname`.
- Plumb the flag through both client and listener FTPS configure paths via a shared `FtpUtil.configureVerifyServerCert` helper.

## ⚠️ Breaking change

FTPS clients that were connecting to self-signed or private-CA servers **without** a configured `cert` will now fail with a PKIX validation error. To restore the old behaviour, users must do one of:
1. (recommended) Configure `secureSocket.cert` with the server's trust chain.
2. Add the server certificate to the JVM's `cacerts` truststore.
3. Set `secureSocket.verifyServerCert: false` — **insecure**, intended only for development.

Documented in `changelog.md` under a new `### Changed` section.

## Tests

- `testFtpsConnectNoCertRejectsUntrustedServer` — confirms the new secure default rejects the mock server's self-signed cert when no truststore is configured (previously silently accepted).
- `testFtpsConnectVerifyServerCertFalseAcceptsUntrustedServer` — confirms the escape hatch works.
- Existing FTPS tests that configure `cert` properly against `keystore.jks` continue to pass.

## Closes

- ballerina-platform/ballerina-library#8761

## Related

- wso2/product-integrator#829 — FTPS hostname verification (separate; not addressed here)

## Test plan

- [ ] CI build + test suite passes.
- [ ] New tests assert both the rejection and the opt-out path.
- [ ] No regression in existing `secure_ftps_*_test.bal` suites — they configure a valid `cert` and hence still succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# FTPS Server Certificate Validation Enabled by Default

## Overview
This pull request enhances the FTPS provider to validate server certificates by default, strengthening connection security. A new configuration flag enables explicit opt-out for development environments where certificate validation is not required.

## Key Changes

**Core Implementation**
- Modified FTPS certificate configuration to always install a TrustManager, regardless of whether `secureSocket.cert` is configured
- When no custom truststore is provided, the JVM's default certificate authority store (`cacerts`) is now used for server certificate validation
- Unvalidated or untrusted server certificates now fail the TLS handshake with appropriate error reporting

**Configuration Control**
- Added `verifyServerCert` boolean field (default: `true`) to the `ftp:SecureSocket` configuration record
- Setting `verifyServerCert: false` disables server certificate validation and emits an explicit warning during connector initialization
- Mirrors the existing `http:SecureSocket.verifyHostname` flag for consistency

**Implementation Across Connector Types**
- Updated both FTPS client and server listener initialization paths to respect the new verification setting
- Introduced `FtpUtil.configureVerifyServerCert()` helper method to propagate the setting through configuration objects

## Testing
- Added test case validating that FTPS connections reject servers with untrusted certificates when no custom truststore is configured
- Added test case confirming that connections succeed when `verifyServerCert: false` is explicitly set
- Existing FTPS tests with configured keystores continue to pass

## Documentation
- Updated changelog to document the new `verifyServerCert` flag under the "Added" section
- Documented the behavioral change under a "Changed" section with guidance on migration options

## Breaking Change
FTPS clients connecting to servers with self-signed or private-CA certificates—where no custom `secureSocket.cert` is configured—will now fail certificate validation. Migration paths include: configuring a custom truststore via `secureSocket.cert`, adding the server certificate to the JVM's default store, or explicitly setting `secureSocket.verifyServerCert: false` for development scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->