### PR TITLE
Clarify the FTP listener "path is not a folder" error message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Apply the content method's `afterError` action when content binding fails before the handler is invoked](https://github.com/wso2/product-integrator/issues/1161)
 - [Validate `fileAgeFilter` values at listener startup; reject negative `minAge`/`maxAge` and `minAge` greater than `maxAge`](https://github.com/wso2/product-integrator/issues/1151)
 - [Enforce hostname verification and JDK cacerts trust chain for FTPS connections by default](https://github.com/wso2/product-integrator/issues/829)
+- [Clarify the FTP listener "path is not a folder" error: name the FTP listener (instead of the unrelated "File system server connector") and include the configured remote path](https://github.com/wso2/product-integrator/issues/1139)
 
 ### Changed
 

--- a/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/RemoteFileSystemConsumer.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/RemoteFileSystemConsumer.java
@@ -92,8 +92,9 @@ public class RemoteFileSystemConsumer {
             listeningDir = fileSystemManager.resolveFile(listeningDirURI, fileSystemOptions);
             FileType fileType = listeningDir.getType();
             if (fileType != FileType.FOLDER) {
-                String errorMsg = "File system server connector is used to "
-                        + "listen to a folder. But the given path does not refer to a folder.";
+                String errorMsg = "FTP listener path \""
+                        + FileTransportUtils.maskUrlPassword(listeningDirURI)
+                        + "\" does not refer to a folder on the remote file system.";
                 final RemoteFileSystemConnectorException e = new RemoteFileSystemConnectorException(errorMsg);
                 remoteFileSystemListener.onError(e);
                 throw e;


### PR DESCRIPTION
## Summary

When `@ftp:ServiceConfig.path` points at something that exists on the remote server but isn't a folder (a regular file, or a typo'd local path used as the remote path), the listener fails with:

> `error: File system server connector is used to listen to a folder. But the given path does not refer to a folder.`

The wording reads like a problem in the local `ballerina/file` listener, not the FTP one. Users debugging a misconfigured `path` (e.g. accidentally using a local Mac path as a remote path) waste time looking for an accidental `ballerina/file` import that isn't even present in their code.

## What changed

`RemoteFileSystemConsumer.consume()` now emits:

```
FTP listener path "sftp://user:***@host:22/wrong/path" does not refer to a folder on the remote file system.
```

- Names the **FTP listener** explicitly so the diagnostic source is unambiguous.
- Includes the configured remote URI (URL-masked via the existing `maskUrlPassword` helper, so credentials are not leaked).
- Says "remote file system" — important because for SFTP/FTPS, the path is on the remote server, not the local filesystem.

One file change in `RemoteFileSystemConsumer.java`, plus a changelog entry.

## Closes

- wso2/product-integrator#1139

## Test plan

- [ ] Existing tests still pass (no behavioural change other than the message text).
- [ ] Manual: configure an `ftp:Listener` with `path` pointing at a regular file on the remote server, run, observe the new error mentions the FTP listener and the configured remote path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Clarify FTP Listener Error Message

This pull request improves the error message displayed when the FTP listener's configured path points to an entry that is not a folder on the remote file system.

**Changes:**
- Updated `RemoteFileSystemConsumer.java` to provide a clearer error message that:
  - Explicitly references the FTP listener (replacing a generic "File system server connector" reference)
  - Displays the configured remote URI with credentials masked for security
  - Clarifies that the path issue occurs on the remote file system
- Added corresponding changelog entry documenting the fix

**Impact:**
Developers will receive more specific and actionable error messages when misconfiguring the FTP listener path, improving troubleshooting experience. The control flow and error handling behavior remain unchanged—only the error message text is enhanced for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->