### PR TITLE
Make ftp:SecureSocket field docs low-code friendly

### DIFF
--- a/ballerina/commons.bal
+++ b/ballerina/commons.bal
@@ -60,19 +60,15 @@ public type PrivateKey record {|
 # Secure socket configuration for FTPS (FTP over SSL/TLS).
 # Used for configuring SSL/TLS certificates and keystores for FTPS connections.
 public type SecureSocket record {|
-    # Keystore configuration for client authentication
+    # Client keystore for mutual TLS
     crypto:KeyStore key?;
-    # Certificate configuration for server certificate validation. Accepts either
-    # a file path string pointing at a PEM certificate (in which case the cert is
-    # loaded into an in-memory truststore) or a `crypto:TrustStore` record for
-    # JKS/PKCS12 truststores.
+    # Server certificate to trust. PEM file path or `crypto:TrustStore` for JKS/PKCS12
     string|crypto:TrustStore cert?;
-    # FTPS connection mode.
+    # When TLS is negotiated. Valid values: `IMPLICIT`, `EXPLICIT`
     FtpsMode mode = EXPLICIT;
-    # Data channel protection level. Controls encryption of the data channel used for file transfers.
+    # Data channel encryption. Valid values: `CLEAR`, `PRIVATE`, `SAFE`, `CONFIDENTIAL`
     FtpsDataChannelProtection dataChannelProtection = PRIVATE;
-    # Verify that the server certificate's CN/SAN matches the host being connected to. Defaults to `true`.
-    # Set to `false` only for development or testing with self-signed certificates whose identity does not match the host.
+    # Verify the server certificate's hostname. Disable only for testing with self-signed certs
     boolean verifyHostName = true;
 |};
 


### PR DESCRIPTION
## Summary
- Tighten the doc strings on `ftp:SecureSocket` so the BI low-code editor surfaces short, actionable field labels instead of multi-line implementation detail.
- One short line per field; `Valid values:` listings inlined for the two enum-typed fields (`mode`, `dataChannelProtection`); security guidance preserved on `verifyHostName`.
- No behavioural change — doc-only tweak. No changelog/spec/test updates needed.

## Test plan
- [ ] `bal doc` renders cleanly (no doc-comment warnings).
- [ ] Spot-check the rendered `SecureSocket` page — each field has a single concise description.
- [ ] BI editor: open a connector that uses `ftp:SecureSocket` and confirm the field tooltips read well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request improves the documentation for the `SecureSocket` record in the FTP module to provide better usability in low-code development environments.

### Changes

The field documentation in `SecureSocket` record is refined to be more concise and user-friendly:

- **Field descriptions** are shortened to single-line summaries that clearly describe each field's purpose
- **Valid values** for enum-typed fields (`mode` and `dataChannelProtection`) are inlined directly into the documentation comments
- **Security guidance** on `verifyHostName` is preserved and simplified for clarity
- Documentation for `key` and `cert` fields is streamlined to focus on their practical use (mutual TLS and server certificate validation)

### Impact

- Improves documentation clarity for developers using the BI low-code editor
- Field tooltips now display concise, actionable labels instead of multi-line technical details
- Documentation is cleaner and renders properly with no warnings
- No functional or behavioral changes — purely documentation updates

### Testing

- Documentation renders cleanly without warnings
- Field descriptions are concise and consistent across the record definition
- Low-code editor integration displays readable field tooltips

<!-- end of auto-generated comment: release notes by coderabbit.ai -->