### PR TITLE
Revert per-slot onError fallback to content method's afterError

### DIFF
--- a/ballerina-tests/ftp-listener-advanced-tests/tests/ftp_listener_content_test.bal
+++ b/ballerina-tests/ftp-listener-advanced-tests/tests/ftp_listener_content_test.bal
@@ -783,8 +783,6 @@ const string CORRUPT_CSV_PAYLOAD = "name,sex,gender\n" +
     "Bob Martinez,34,Male\n";
 
 isolated boolean corruptCsvHandlerInvoked = false;
-isolated boolean onErrorCorruptCsvInvoked = false;
-isolated boolean corruptCsvHandlerB = false;
 isolated boolean corruptCsvHandlerC = false;
 isolated boolean corruptCsvOnErrorC = false;
 
@@ -843,66 +841,11 @@ function testFunctionConfig_CorruptCsvRoutesToAfterError() returns error? {
     check contentFtpClient->delete(movedPath);
 }
 
-// onError declared without its own post-process actions → fall back to the content method's
-// afterError, and onError is still invoked for notification.
-@test:Config {
-    groups: ["ftp-listener-advanced", "function-config"],
-    dependsOn: [testFunctionConfig_CorruptCsvRoutesToAfterError]
-}
-function testFunctionConfig_CorruptCsv_OnErrorWithoutActions() returns error? {
-    lock { onErrorCorruptCsvInvoked = false; }
-    lock { corruptCsvHandlerB = false; }
-
-    ftp:Service svc = service object {
-        @ftp:FunctionConfig {
-            afterProcess: {moveTo: CORRUPT_CSV_PROCESSED_DIR},
-            afterError: {moveTo: CORRUPT_CSV_ERROR_DIR}
-        }
-        remote function onFileCsv(CorruptCsvContent[] contents, ftp:FileInfo fileInfo) returns error? {
-            lock { corruptCsvHandlerB = true; }
-        }
-
-        remote function onError(ftp:Error err) returns error? {
-            lock { onErrorCorruptCsvInvoked = true; }
-        }
-    };
-
-    ftp:Listener l = check new (contentListenerConfig(CORRUPT_CSV_DIR, "cbe-onerr-noact.*\\.csv", 2));
-    check l.attach(svc);
-    check l.'start();
-    runtime:registerListener(l);
-
-    string remotePath = CORRUPT_CSV_DIR + "/cbe-onerr-noact.csv";
-    string movedPath = CORRUPT_CSV_ERROR_DIR + "/cbe-onerr-noact.csv";
-    check contentFtpClient->putText(remotePath, CORRUPT_CSV_PAYLOAD);
-
-    boolean moved = waitUntilFileAt(movedPath);
-
-    runtime:deregisterListener(l);
-    check l.gracefulStop();
-
-    boolean onErrorCalled;
-    lock { onErrorCalled = onErrorCorruptCsvInvoked; }
-    boolean handlerCalled;
-    lock { handlerCalled = corruptCsvHandlerB; }
-    test:assertFalse(handlerCalled,
-        "onFileCsv must not be invoked when binding fails");
-    test:assertTrue(onErrorCalled, "onError should be invoked for a ContentBindingError");
-    test:assertTrue(moved,
-        "Corrupted CSV should fall back to the content method's afterError directory");
-
-    boolean inSource = check contentFtpClient->exists(remotePath);
-    test:assertFalse(inSource,
-        "Corrupted CSV must be removed from the source directory (the core regression)");
-
-    check contentFtpClient->delete(movedPath);
-}
-
 // onError declared with its own afterProcess; onError returns success → onError's
 // afterProcess wins; content method's afterError is suppressed.
 @test:Config {
     groups: ["ftp-listener-advanced", "function-config"],
-    dependsOn: [testFunctionConfig_CorruptCsv_OnErrorWithoutActions]
+    dependsOn: [testFunctionConfig_CorruptCsvRoutesToAfterError]
 }
 function testFunctionConfig_CorruptCsv_OnErrorWithOwnActions() returns error? {
     lock { corruptCsvHandlerC = false; }

--- a/ballerina-tests/ftp-listener-advanced-tests/tests/ftp_listener_content_test.bal
+++ b/ballerina-tests/ftp-listener-advanced-tests/tests/ftp_listener_content_test.bal
@@ -785,6 +785,8 @@ const string CORRUPT_CSV_PAYLOAD = "name,sex,gender\n" +
 isolated boolean corruptCsvHandlerInvoked = false;
 isolated boolean corruptCsvHandlerC = false;
 isolated boolean corruptCsvOnErrorC = false;
+isolated boolean corruptCsvHandlerD = false;
+isolated boolean corruptCsvOnErrorD = false;
 
 function waitUntilFileAt(string path) returns boolean {
     return waitUntil(function() returns boolean {
@@ -902,4 +904,73 @@ function testFunctionConfig_CorruptCsv_OnErrorWithOwnActions() returns error? {
         "Content method's afterError must be suppressed when onError declares the afterProcess slot");
 
     check contentFtpClient->delete(movedPath);
+}
+
+// onError declared without its own @ftp:FunctionConfig actions → onError fires for notification,
+// but no post-process action runs and the corrupted file stays in the source directory.
+// Negative regression: prevents reintroduction of the per-slot fallback to the content method's
+// afterError when onError is declared.
+@test:Config {
+    groups: ["ftp-listener-advanced", "function-config"],
+    dependsOn: [testFunctionConfig_CorruptCsv_OnErrorWithOwnActions]
+}
+function testFunctionConfig_CorruptCsv_OnErrorWithoutActions_FileStaysInSource() returns error? {
+    lock { corruptCsvHandlerD = false; }
+    lock { corruptCsvOnErrorD = false; }
+
+    ftp:Service svc = service object {
+        @ftp:FunctionConfig {
+            afterProcess: {moveTo: CORRUPT_CSV_PROCESSED_DIR},
+            afterError: {moveTo: CORRUPT_CSV_ERROR_DIR}
+        }
+        remote function onFileCsv(CorruptCsvContent[] contents, ftp:FileInfo fileInfo) returns error? {
+            lock { corruptCsvHandlerD = true; }
+        }
+
+        // No @ftp:FunctionConfig — onError declared without its own afterProcess/afterError.
+        remote function onError(ftp:Error err) returns error? {
+            lock { corruptCsvOnErrorD = true; }
+        }
+    };
+
+    ftp:Listener l = check new (contentListenerConfig(CORRUPT_CSV_DIR, "cbe-onerr-noact.*\\.csv", 2));
+    check l.attach(svc);
+    check l.'start();
+    runtime:registerListener(l);
+
+    string remotePath = CORRUPT_CSV_DIR + "/cbe-onerr-noact.csv";
+    check contentFtpClient->putText(remotePath, CORRUPT_CSV_PAYLOAD);
+
+    boolean onErrorCalled = waitUntil(function() returns boolean {
+        boolean called;
+        lock { called = corruptCsvOnErrorD; }
+        return called;
+    }, 30);
+
+    // After onError signals, give any spurious post-process action time to complete before
+    // asserting nothing moved. Two polling intervals is enough to detect a fallback.
+    runtime:sleep(5);
+
+    runtime:deregisterListener(l);
+    check l.gracefulStop();
+
+    boolean handlerCalled;
+    lock { handlerCalled = corruptCsvHandlerD; }
+    test:assertFalse(handlerCalled,
+        "onFileCsv must not be invoked when binding fails");
+    test:assertTrue(onErrorCalled, "onError should be invoked for a ContentBindingError");
+
+    boolean inSource = check contentFtpClient->exists(remotePath);
+    test:assertTrue(inSource,
+        "When onError is declared without @FunctionConfig actions, the file must stay in " +
+        "the source directory — no per-slot fallback to the content method's afterError");
+
+    boolean inErrorDir = check contentFtpClient->exists(CORRUPT_CSV_ERROR_DIR + "/cbe-onerr-noact.csv");
+    test:assertFalse(inErrorDir,
+        "Content method's afterError must not fire when onError is declared without actions");
+
+    boolean inProcessedDir = check contentFtpClient->exists(CORRUPT_CSV_PROCESSED_DIR + "/cbe-onerr-noact.csv");
+    test:assertFalse(inProcessedDir, "afterProcess must not fire on binding failure");
+
+    check contentFtpClient->delete(remotePath);
 }

--- a/ballerina/annotations.bal
+++ b/ballerina/annotations.bal
@@ -39,12 +39,8 @@ public type FtpFunctionConfig record {|
     # If not specified, no action is taken (file remains in place)
     MOVE|DELETE afterProcess?;
     # Action to perform after a processing error. Can be `DELETE` or `MOVE`.
-    # Executed immediately after the content handler returns an error or panics,
-    # or when content binding fails before the handler is invoked (e.g. malformed
-    # CSV/JSON/XML for the target type). On binding failures, any slot an
-    # `onError` method declares (`afterProcess` or `afterError` on its own
-    # `FunctionConfig`) takes precedence; slots it leaves empty fall back to
-    # this action.
+    # Also applied when content binding fails (e.g. malformed CSV/JSON/XML) and
+    # no `onError` method is declared.
     # If not specified, no action is taken (file remains in place)
     MOVE|DELETE afterError?;
 |};

--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- [Apply the content method's `afterError` action when content binding fails before the handler is invoked](https://github.com/wso2/product-integrator/issues/1161)
+- [Apply the content method's `afterError` action when content binding fails before the handler is invoked and no `onError` method is declared](https://github.com/wso2/product-integrator/issues/1161)
 - [Validate `fileAgeFilter` values at listener startup; reject negative `minAge`/`maxAge` and `minAge` greater than `maxAge`](https://github.com/wso2/product-integrator/issues/1151)
 - [Enforce hostname verification and JDK cacerts trust chain for FTPS connections by default](https://github.com/wso2/product-integrator/issues/829)
 - [Improve error messages for SFTP private-key load failures — surface the configured path and a useful hint instead of the Java object identity](https://github.com/ballerina-platform/ballerina-library/issues/8760)

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -308,16 +308,14 @@ public class FtpContentCallbackHandler {
 
     private void routeToOnError(BObject service, FormatMethodsHolder holder, BError error, BObject callerObject,
                                 FileInfo fileInfo, String listenerPath, String contentMethodName) {
-        // Binding failed before the content handler ran — the content method's afterError is the
-        // user's declared "corrupted file" destination. It is the fallback for any post-process
-        // slot the onError method's @FunctionConfig does not declare.
-        Optional<PostProcessAction> contentAfterError = holder.getAfterErrorAction(contentMethodName);
-
         Optional<MethodType> onErrorMethodOpt = holder.getOnErrorMethod();
         if (onErrorMethodOpt.isEmpty()) {
+            // No onError handler — fall back to the content method's afterError so the
+            // corrupted source file does not get re-picked on every poll.
             error.printStackTrace();
-            contentAfterError.ifPresent(action -> Thread.startVirtualThread(() ->
-                    executePostProcessAction(action, fileInfo, callerObject, listenerPath, ACTION_AFTER_ERROR)));
+            holder.getAfterErrorAction(contentMethodName).ifPresent(action ->
+                    Thread.startVirtualThread(() -> executePostProcessAction(action, fileInfo,
+                            callerObject, listenerPath, ACTION_AFTER_ERROR)));
             return;
         }
 
@@ -325,18 +323,13 @@ public class FtpContentCallbackHandler {
 
         Optional<PostProcessAction> onErrorAfterProcess = holder.getAfterProcessAction(onErrorMethod.getName());
         Optional<PostProcessAction> onErrorAfterError = holder.getAfterErrorAction(onErrorMethod.getName());
-
-        // Per slot: honour what onError declares; fall back to the content method's afterError
-        // for any slot onError left empty. The source file already failed binding, so an empty
-        // slot must not mean "do nothing" — it means "use the content method's afterError".
-        Optional<PostProcessAction> effectiveAfterProcess =
-                onErrorAfterProcess.isPresent() ? onErrorAfterProcess : contentAfterError;
-        Optional<PostProcessAction> effectiveAfterError =
-                onErrorAfterError.isPresent() ? onErrorAfterError : contentAfterError;
+        boolean hasOnErrorActions = onErrorAfterProcess.isPresent() || onErrorAfterError.isPresent();
 
         Object[] methodArguments = prepareOnErrorMethodArguments(onErrorMethod, error, callerObject);
         invokeOnErrorMethodAsync(service, onErrorMethod.getName(), methodArguments, fileInfo, callerObject,
-                listenerPath, effectiveAfterProcess, effectiveAfterError);
+                listenerPath,
+                hasOnErrorActions ? onErrorAfterProcess : Optional.empty(),
+                hasOnErrorActions ? onErrorAfterError : Optional.empty());
     }
 
     private Object[] prepareOnErrorMethodArguments(MethodType methodType, BError error, BObject callerObject) {


### PR DESCRIPTION
## Summary

Partial revert of #1565. PR #1565 introduced two rules for routing content-binding failures:

1. **No `onError` declared** → apply the content method's `afterError`. (the original bug fix for the corrupted source file being re-picked on every poll)
2. **`onError` declared without its own actions** → still apply the content method's `afterError` while invoking `onError`.

Rule 2 conflates notification with file disposition and surprises users who declared `onError` purely for logging — they did not opt into having their files moved.

This PR keeps rule 1 and reverts rule 2: when `onError` is declared, only its own `@FunctionConfig` actions drive post-processing. Empty slots stay empty, matching the pre-#1565 contract.

## Behaviour after this PR

| trigger | content `afterError` | `onError` declared? | `onError` actions | result |
|---|---|---|---|---|
| binding fails | set | no | — | content `afterError` fires |
| binding fails | set | yes | none | `onError` runs; **no** post-process action (file stays) |
| binding fails | set | yes | own `afterProcess`/`afterError` | `onError`'s actions drive disposition |

## Changes

- `FtpContentCallbackHandler.routeToOnError`: restored the original `hasOnErrorActions` gate; removed per-slot fallback to the content method's `afterError`.
- `FtpFunctionConfig.afterError` doc: trimmed the per-slot precedence wording; only mentions binding-failure routing for the no-`onError` case.
- Dropped the now-obsolete `testFunctionConfig_CorruptCsv_OnErrorWithoutActions` regression test; rewired `OnErrorWithOwnActions` `dependsOn` accordingly.
- Changelog entry for #1161 narrowed to "...and no `onError` method is declared".

## Test plan

- [x] `./gradlew :ftp-native:compileJava :ftp-native:checkstyleMain`
- [ ] CI FTP harness runs the remaining `CorruptCsvRoutesToAfterError` and `CorruptCsv_OnErrorWithOwnActions` regression tests.