### PR TITLE
Add observability support for the FTP library

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ftp"
-version = "2.19.0"
+version = "2.19.1"
 authors = ["Ballerina"]
 keywords = ["FTP", "SFTP", "remote file", "file transfer", "client", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-ftp"
@@ -46,8 +46,8 @@ path = "./lib/commons-lang3-3.18.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ftp-native"
-version = "2.19.0"
-path = "../native/build/libs/ftp-native-2.19.0.jar"
+version = "2.19.1"
+path = "../native/build/libs/ftp-native-2.19.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ftp"
-version = "2.19.1"
+version = "2.20.0"
 authors = ["Ballerina"]
 keywords = ["FTP", "SFTP", "remote file", "file transfer", "client", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-ftp"
@@ -46,8 +46,8 @@ path = "./lib/commons-lang3-3.18.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ftp-native"
-version = "2.19.1"
-path = "../native/build/libs/ftp-native-2.19.1-SNAPSHOT.jar"
+version = "2.20.0"
+path = "../native/build/libs/ftp-native-2.20.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "ftp-compiler-plugin"
 class = "io.ballerina.stdlib.ftp.plugin.FtpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.19.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.20.0-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "ftp-compiler-plugin"
 class = "io.ballerina.stdlib.ftp.plugin.FtpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.19.0.jar"
+path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.19.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -58,7 +58,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.19.0"
+version = "2.19.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -58,7 +58,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.19.1"
+version = "2.20.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.csv"},

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - [Add observability support for the FTP client and listener](https://github.com/ballerina-platform/ballerina-library/issues/8790)
+
+## [2.19.0] - 2026-04-27
+
+### Added
+
 - Added `verifyHostName` field (default `true`) to `ftp:SecureSocket` to verify FTPS server certificate CN/SAN against the connect host.
 - [Extend `ftp:SecureSocket.cert` to accept a PEM file path string in addition to `crypto:TrustStore` (parity with `http:SecureSocket`)](https://github.com/wso2/product-integrator/issues/830)
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- [Add observability support for the FTP client and listener](https://github.com/ballerina-platform/ballerina-library/issues/8790)
 - Added `verifyHostName` field (default `true`) to `ftp:SecureSocket` to verify FTPS server certificate CN/SAN against the connect host.
 - [Extend `ftp:SecureSocket.cert` to accept a PEM file path string in addition to `crypto:TrustStore` (parity with `http:SecureSocket`)](https://github.com/wso2/product-integrator/issues/830)
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -817,26 +817,23 @@ All metrics and trace spans carry tags that identify the connection and operatio
 | `remote.url` | `host:port` of the remote server | Metrics, Traces |
 | `protocol` | `ftp`, `ftps`, `sftp` | Metrics, Traces |
 | `host` | Hostname of the current node | Metrics, Traces |
-| `operation.type` | `get`, `put`, `delete`, `rename`, `move`, `copy`, `mkdir`, `rmdir` | Traces (on `action.type=operation` spans only) |
-| `event.type` | `create`, `delete`, `error` | Traces (on `action.type=event` spans) |
-| `error.type` | `connection`, `authentication`, `file_not_found`, `file_already_exists`, `service_unavailable`, `content_binding`, `retry_exhausted`, `circuit_breaker_open`, `invalid_config`, `close` | Traces (on `event.type=error` spans) |
+| `operation.type` | `get`, `put`, `admin` | Metrics, Traces (on `action.type=operation` spans only) |
+| `event.type` | `create`, `delete`, `error` | Metrics, Traces (on `action.type=event` spans) |
+| `error.type` | `ConnectionError`, `AuthenticationError`, `FileNotFoundError`, `FileAlreadyExistsError`, `ServiceUnavailableError`, `ContentBindingError`, `RetryError`, `CircuitBreakerOpenError`, `InvalidConfigError`, `CloseError` | Metrics, Traces (on `event.type=error` spans) |
 | `file.path` | Source/target file path of the operation | Traces only |
 | `destination.path` | Destination path for two-path operations (`rename`, `move`, `copy`) | Traces only |
 
 `file.path` and `destination.path` are intentionally excluded from metrics to avoid unbounded label cardinality. They are captured on trace spans only.
 
+> **Note:** Prometheus normalizes `.` to `_` in label names (e.g. `action.type` → `action_type`, `operation.type` → `operation_type`). Jaeger and other trace backends preserve the original dotted names. The PromQL examples in §7.3 use the Prometheus-normalized form.
+
 Client operation spans use `context=client` and `action.type=operation`. The `operation.type` tag maps to the client method invoked:
 
 | `operation.type` | Triggered by |
 |---|---|
-| `get` | `getBytes()`, `getText()`, `getJson()`, `getXml()`, `getCsv()`, `getBytesAsStream()`, `getCsvAsStream()`, `isDirectory()`, `list()`, `exists()`, `size()` |
+| `get` | `getBytes()`, `getText()`, `getJson()`, `getXml()`, `getCsv()`, `getBytesAsStream()`, `getCsvAsStream()` |
 | `put` | `putBytes()`, `putText()`, `putJson()`, `putXml()`, `putCsv()`, `putBytesAsStream()`, `putCsvAsStream()` |
-| `delete` | `delete()` |
-| `rename` | `rename()` |
-| `move` | `move()` |
-| `copy` | `copy()` |
-| `mkdir` | `mkdir()` |
-| `rmdir` | `rmdir()` |
+| `admin` | `delete()`, `rename()`, `move()`, `copy()`, `mkdir()`, `rmdir()`, `isDirectory()`, `list()`, `exists()`, `size()` |
 
 For `getBytesAsStream()` and `getCsvAsStream()`, the `error.type` tag is not added to the span when an error occurs inside the async callback because the Ballerina strand is suspended at that point. Operation tags are still applied before the yield.
 
@@ -850,20 +847,20 @@ Listener event spans use `context=listener` and `action.type=event`. The `event.
 
 Transport-level errors (e.g. polling connection failures) do not generate a span or metric entry. Only errors dispatched to the service's `onError` callback are recorded.
 
-When errors are dispatched to `onError`, the span includes both `event.type=error` and an `error.type` tag:
+When errors are dispatched to `onError`, the span includes both `event.type=error` and an `error.type` tag set to the Ballerina error type name:
 
-| `error.type` | Corresponding Ballerina error |
+| `error.type` | Ballerina error |
 |---|---|
-| `connection` | `ftp:ConnectionError` |
-| `authentication` | `ftp:AuthenticationError` |
-| `file_not_found` | `ftp:FileNotFoundError` |
-| `file_already_exists` | `ftp:FileAlreadyExistsError` |
-| `service_unavailable` | `ftp:ServiceUnavailableError` |
-| `content_binding` | `ftp:ContentBindingError` |
-| `retry_exhausted` | `ftp:AllRetryAttemptsFailedError` |
-| `circuit_breaker_open` | `ftp:CircuitBreakerOpenError` |
-| `invalid_config` | `ftp:InvalidConfigError` |
-| `close` | Error while closing a connection |
+| `ConnectionError` | `ftp:ConnectionError` |
+| `AuthenticationError` | `ftp:AuthenticationError` |
+| `FileNotFoundError` | `ftp:FileNotFoundError` |
+| `FileAlreadyExistsError` | `ftp:FileAlreadyExistsError` |
+| `ServiceUnavailableError` | `ftp:ServiceUnavailableError` |
+| `ContentBindingError` | `ftp:ContentBindingError` |
+| `RetryError` | `ftp:RetryError` |
+| `CircuitBreakerOpenError` | `ftp:CircuitBreakerOpenError` |
+| `InvalidConfigError` | `ftp:InvalidConfigError` |
+| `CloseError` | Error while closing a connection |
 
 ### 7.3 Deriving Counts from `requests_total_value`
 
@@ -871,7 +868,7 @@ Since the Ballerina runtime automatically publishes `requests_total_value` for e
 
 ```promql
 # Client file operations by type
-rate(requests_total_value{action_type="operation", operation_type="put", protocol="sftp"}[1m])
+rate(requests_total_value{action_type="operation", operation_type="admin", protocol="sftp"}[1m])
 
 # Listener file events by type
 rate(requests_total_value{action_type="event", event_type="create"}[1m])

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -818,7 +818,7 @@ All metrics and trace spans carry tags that identify the connection and operatio
 | `protocol` | `ftp`, `ftps`, `sftp` | Metrics, Traces |
 | `host` | Hostname of the current node | Metrics, Traces |
 | `operation.type` | `get`, `put`, `delete`, `rename`, `move`, `copy`, `mkdir`, `rmdir` | Traces (on `action.type=operation` spans only) |
-| `event.type` | `change`, `delete`, `error` | Traces (on `action.type=event` spans) |
+| `event.type` | `create`, `delete`, `error` | Traces (on `action.type=event` spans) |
 | `error.type` | `connection`, `authentication`, `file_not_found`, `file_already_exists`, `service_unavailable`, `content_binding`, `retry_exhausted`, `circuit_breaker_open`, `invalid_config`, `close` | Traces (on `event.type=error` spans) |
 | `file.path` | Source/target file path of the operation | Traces only |
 | `destination.path` | Destination path for two-path operations (`rename`, `move`, `copy`) | Traces only |
@@ -844,7 +844,7 @@ Listener event spans use `context=listener` and `action.type=event`. The `event.
 
 | `event.type` | Triggered by |
 |---|---|
-| `change` | File added or modified; dispatched to format-specific callbacks or `onFileChange` |
+| `create` | File added or modified; dispatched to format-specific callbacks or `onFileChange` |
 | `delete` | File deleted; dispatched to `onFileDelete` |
 | `error` | Content-binding or deserialization failure; dispatched to `onError` |
 
@@ -874,7 +874,7 @@ Since the Ballerina runtime automatically publishes `requests_total_value` for e
 rate(requests_total_value{action_type="operation", operation_type="put", protocol="sftp"}[1m])
 
 # Listener file events by type
-rate(requests_total_value{action_type="event", event_type="change"}[1m])
+rate(requests_total_value{action_type="event", event_type="create"}[1m])
 
 # Errors by category (dispatched to onError)
 sum by (error_type) (

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Owners_: @shafreenAnfar @dilanSachi @Bhashinee \
 _Reviewers_: @shafreenAnfar @Bhashinee \
 _Created_: 2020/10/28 \
-_Updated_: 2026/03/10 \
+_Updated_: 2026/05/20 \
 _Edition_: Swan Lake
 
 ## Introduction
@@ -62,6 +62,11 @@ The conforming implementation of the specification is released and included in t
 6. [Errors](#6-errors)
    * 6.1 [Error Hierarchy](#61-error-hierarchy)
    * 6.2 [Error Handling](#62-error-handling)
+7. [Observability](#7-observability)
+   * 7.1 [Metrics](#71-metrics)
+   * 7.2 [Tags](#72-tags)
+   * 7.3 [Deriving Counts from `requests_total_value`](#73-deriving-counts-from-requests_total_value)
+   * 7.4 [Enabling Observability](#74-enabling-observability)
 
 ## 1. Overview
 
@@ -784,3 +789,112 @@ if result is ftp:CircuitBreakerOpenError {
     processBytes(result);
 }
 ```
+
+## 7. Observability
+
+The FTP library provides built-in observability support through metrics and distributed tracing. When observability is enabled in the Ballerina runtime, the FTP client and listener automatically report telemetry data without any additional configuration.
+
+### 7.1 Metrics
+
+The following metric is published directly:
+
+| Metric Name | Type | Description |
+|---|---|---|
+| `ftp_active_connections` | Gauge | Number of active FTP/FTPS/SFTP connections |
+
+File operation counts, event counts, and error counts are derived from the Ballerina framework's built-in `requests_total_value` metric by filtering on the tags published on each span.
+
+The `ftp_active_connections` gauge is incremented when a client or listener is initialized and decremented when it is closed. If an exception occurs during `close()`, the gauge is still decremented — the connection is treated as closed regardless of the close error.
+
+### 7.2 Tags
+
+All metrics and trace spans carry tags that identify the connection and operation:
+
+| Tag | Values | Used In |
+|---|---|---|
+| `context` | `client`, `listener` | Metrics, Traces |
+| `action.type` | `operation`, `event` | Metrics, Traces |
+| `remote_url` | `host:port` of the remote server | Metrics, Traces |
+| `protocol` | `ftp`, `ftps`, `sftp` | Metrics, Traces |
+| `instance.url` | Hostname of the current node | Metrics, Traces |
+| `operation.type` | `get`, `put`, `delete`, `rename`, `move`, `copy`, `mkdir`, `rmdir` | Traces (on `action.type=operation` spans only) |
+| `event.type` | `change`, `delete`, `error` | Traces (on `action.type=event` spans) |
+| `error_type` | `connection`, `authentication`, `file_not_found`, `file_already_exists`, `service_unavailable`, `content_binding`, `retry_exhausted`, `circuit_breaker_open`, `invalid_config`, `close` | Traces (on `event.type=error` spans) |
+| `file.path` | Source/target file path of the operation | Traces only |
+| `destination.path` | Destination path for two-path operations (`rename`, `move`, `copy`) | Traces only |
+
+`file.path` and `destination.path` are intentionally excluded from metrics to avoid unbounded label cardinality. They are captured on trace spans only.
+
+Client operation spans use `context=client` and `action.type=operation`. The `operation.type` tag maps to the client method invoked:
+
+| `operation.type` | Triggered by |
+|---|---|
+| `get` | `getBytes()`, `getText()`, `getJson()`, `getXml()`, `getCsv()`, `getBytesAsStream()`, `getCsvAsStream()`, `isDirectory()`, `list()`, `exists()`, `size()` |
+| `put` | `putBytes()`, `putText()`, `putJson()`, `putXml()`, `putCsv()`, `putBytesAsStream()`, `putCsvAsStream()` |
+| `delete` | `delete()` |
+| `rename` | `rename()` |
+| `move` | `move()` |
+| `copy` | `copy()` |
+| `mkdir` | `mkdir()` |
+| `rmdir` | `rmdir()` |
+
+For `getBytesAsStream()` and `getCsvAsStream()`, the `error_type` tag is not added to the span when an error occurs inside the async callback because the Ballerina strand is suspended at that point. Operation tags are still applied before the yield.
+
+Listener event spans use `context=listener` and `action.type=event`. The `event.type` tag identifies the event:
+
+| `event.type` | Triggered by |
+|---|---|
+| `change` | File added or modified; dispatched to format-specific callbacks or `onFileChange` |
+| `delete` | File deleted; dispatched to `onFileDelete` |
+| `error` | Content-binding or deserialization failure; dispatched to `onError` |
+
+Transport-level errors (e.g. polling connection failures) do not generate a span or metric entry. Only errors dispatched to the service's `onError` callback are recorded.
+
+When errors are dispatched to `onError`, the span includes both `event.type=error` and an `error_type` tag:
+
+| `error_type` | Corresponding Ballerina error |
+|---|---|
+| `connection` | `ftp:ConnectionError` |
+| `authentication` | `ftp:AuthenticationError` |
+| `file_not_found` | `ftp:FileNotFoundError` |
+| `file_already_exists` | `ftp:FileAlreadyExistsError` |
+| `service_unavailable` | `ftp:ServiceUnavailableError` |
+| `content_binding` | `ftp:ContentBindingError` |
+| `retry_exhausted` | `ftp:AllRetryAttemptsFailedError` |
+| `circuit_breaker_open` | `ftp:CircuitBreakerOpenError` |
+| `invalid_config` | `ftp:InvalidConfigError` |
+| `close` | Error while closing a connection |
+
+### 7.3 Deriving Counts from `requests_total_value`
+
+Since the Ballerina runtime automatically publishes `requests_total_value` for each observed span, operation and event counts can be derived using PromQL queries:
+
+```promql
+# Client file operations by type
+rate(requests_total_value{action_type="operation", operation_type="put", protocol="sftp"}[1m])
+
+# Listener file events by type
+rate(requests_total_value{action_type="event", event_type="change"}[1m])
+
+# Errors by category (dispatched to onError)
+sum by (error_type) (
+  rate(requests_total_value{action_type="event", event_type="error"}[5m])
+)
+
+# All FTP activity on a specific node
+rate(requests_total_value{instance_url="node-1", src_module=~"ballerina/ftp.*"}[1m])
+```
+
+### 7.4 Enabling Observability
+
+Observability must be enabled in the Ballerina runtime configuration. Add the following to `Config.toml`:
+
+```toml
+[ballerina.observe]
+metricsEnabled=true
+metricsReporter="prometheus"
+tracingEnabled=true
+tracingProvider="jaeger"
+```
+
+Refer to the [Ballerina Observability documentation](https://ballerina.io/learn/observe-ballerina-programs/) for details on configuring reporters and exporters.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -814,12 +814,12 @@ All metrics and trace spans carry tags that identify the connection and operatio
 |---|---|---|
 | `context` | `client`, `listener` | Metrics, Traces |
 | `action.type` | `operation`, `event` | Metrics, Traces |
-| `remote_url` | `host:port` of the remote server | Metrics, Traces |
+| `remote.url` | `host:port` of the remote server | Metrics, Traces |
 | `protocol` | `ftp`, `ftps`, `sftp` | Metrics, Traces |
-| `instance.url` | Hostname of the current node | Metrics, Traces |
+| `host` | Hostname of the current node | Metrics, Traces |
 | `operation.type` | `get`, `put`, `delete`, `rename`, `move`, `copy`, `mkdir`, `rmdir` | Traces (on `action.type=operation` spans only) |
 | `event.type` | `change`, `delete`, `error` | Traces (on `action.type=event` spans) |
-| `error_type` | `connection`, `authentication`, `file_not_found`, `file_already_exists`, `service_unavailable`, `content_binding`, `retry_exhausted`, `circuit_breaker_open`, `invalid_config`, `close` | Traces (on `event.type=error` spans) |
+| `error.type` | `connection`, `authentication`, `file_not_found`, `file_already_exists`, `service_unavailable`, `content_binding`, `retry_exhausted`, `circuit_breaker_open`, `invalid_config`, `close` | Traces (on `event.type=error` spans) |
 | `file.path` | Source/target file path of the operation | Traces only |
 | `destination.path` | Destination path for two-path operations (`rename`, `move`, `copy`) | Traces only |
 
@@ -838,7 +838,7 @@ Client operation spans use `context=client` and `action.type=operation`. The `op
 | `mkdir` | `mkdir()` |
 | `rmdir` | `rmdir()` |
 
-For `getBytesAsStream()` and `getCsvAsStream()`, the `error_type` tag is not added to the span when an error occurs inside the async callback because the Ballerina strand is suspended at that point. Operation tags are still applied before the yield.
+For `getBytesAsStream()` and `getCsvAsStream()`, the `error.type` tag is not added to the span when an error occurs inside the async callback because the Ballerina strand is suspended at that point. Operation tags are still applied before the yield.
 
 Listener event spans use `context=listener` and `action.type=event`. The `event.type` tag identifies the event:
 
@@ -850,9 +850,9 @@ Listener event spans use `context=listener` and `action.type=event`. The `event.
 
 Transport-level errors (e.g. polling connection failures) do not generate a span or metric entry. Only errors dispatched to the service's `onError` callback are recorded.
 
-When errors are dispatched to `onError`, the span includes both `event.type=error` and an `error_type` tag:
+When errors are dispatched to `onError`, the span includes both `event.type=error` and an `error.type` tag:
 
-| `error_type` | Corresponding Ballerina error |
+| `error.type` | Corresponding Ballerina error |
 |---|---|
 | `connection` | `ftp:ConnectionError` |
 | `authentication` | `ftp:AuthenticationError` |
@@ -882,7 +882,7 @@ sum by (error_type) (
 )
 
 # All FTP activity on a specific node
-rate(requests_total_value{instance_url="node-1", src_module=~"ballerina/ftp.*"}[1m])
+rate(requests_total_value{host="node-1", src_module=~"ballerina/ftp.*"}[1m])
 ```
 
 ### 7.4 Enabling Observability

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.19.1-SNAPSHOT
+version=2.20.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 testngVersion=7.6.1

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -667,12 +667,8 @@ public class FtpClient {
                 readInputStream.close();
                 clientObject.addNativeData(READ_INPUT_STREAM, null);
                 clientObject.addNativeData(ENTITY_BYTE_STREAM, null);
-                FtpMetricsUtil.reportConnectionClose(getRemoteUrl(clientObject), getProtocol(clientObject),
-                        FtpMetricsUtil.CONTEXT_CLIENT);
                 return null;
             } catch (IOException e) {
-                FtpMetricsUtil.reportConnectionClose(getRemoteUrl(clientObject), getProtocol(clientObject),
-                        FtpMetricsUtil.CONTEXT_CLIENT);
                 return IOUtils.createError(e);
             }
         } else {
@@ -691,6 +687,7 @@ public class FtpClient {
             connector.close();
         } catch (Exception exception) {
             clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
+            FtpMetricsUtil.reportConnectionClose(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT);
             return FtpUtil.createError(ON_CLOSE_ERROR + exception.getMessage(), exception, FTP_ERROR);
         }
         clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -691,7 +691,6 @@ public class FtpClient {
             connector.close();
         } catch (Exception exception) {
             clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
-            FtpMetricsUtil.reportConnectionClose(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT);
             return FtpUtil.createError(ON_CLOSE_ERROR + exception.getMessage(), exception, FTP_ERROR);
         }
         clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -39,8 +39,6 @@ import io.ballerina.stdlib.ftp.exception.BallerinaFtpException;
 import io.ballerina.stdlib.ftp.exception.FtpInvalidConfigException;
 import io.ballerina.stdlib.ftp.exception.RemoteFileSystemConnectorException;
 import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
-import io.ballerina.stdlib.ftp.observability.FtpObserverContext;
-import io.ballerina.stdlib.ftp.observability.FtpTracingUtil;
 import io.ballerina.stdlib.ftp.transport.RemoteFileSystemConnectorFactory;
 import io.ballerina.stdlib.ftp.transport.client.connector.contract.FtpAction;
 import io.ballerina.stdlib.ftp.transport.client.connector.contract.VfsClientConnector;
@@ -508,8 +506,6 @@ public class FtpClient {
     public static Object getBytes(Environment env, BObject clientConnector, BString filePath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_BYTES, null);
-        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
@@ -531,8 +527,6 @@ public class FtpClient {
     public static Object getText(Environment env, BObject clientConnector, BString filePath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_TEXT, null);
-        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
@@ -554,8 +548,6 @@ public class FtpClient {
     public static Object getJson(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_JSON, null);
-        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
@@ -579,8 +571,6 @@ public class FtpClient {
     public static Object getXml(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_XML, null);
-        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
@@ -604,8 +594,6 @@ public class FtpClient {
     public static Object getCsv(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_CSV, null);
-        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         BMap<?, ?> csvFailSafe = (BMap<?, ?>) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_CSV_FAIL_SAFE);
         String fileNamePrefix = deriveFileNamePrefix(filePath);
@@ -642,8 +630,6 @@ public class FtpClient {
 
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_BYTES_AS_STREAM, null);
-        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         return env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
@@ -677,8 +663,6 @@ public class FtpClient {
 
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_CSV_AS_STREAM, null);
-        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         return env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
@@ -1035,8 +1019,6 @@ public class FtpClient {
 
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_PUT, functionName, null);
-        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         return env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
             CompletableFuture<Object> balFuture = new CompletableFuture<>();
@@ -1060,8 +1042,6 @@ public class FtpClient {
     public static Object delete(Environment env, BObject clientConnector, BString filePath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_DELETE, FN_DELETE, null);
-        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_DELETE, filePath.getValue());
         Object result = executeSinglePathAction(env, clientConnector, filePath, FtpAction.DELETE, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
@@ -1092,8 +1072,6 @@ public class FtpClient {
     public static Object mkdir(Environment env, BObject clientConnector, BString path) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_MKDIR, FN_MKDIR, null);
-        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_MKDIR, path.getValue());
         Object result = executeSinglePathAction(env, clientConnector, path, FtpAction.MKDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
@@ -1108,8 +1086,6 @@ public class FtpClient {
     public static Object rename(Environment env, BObject clientConnector, BString origin, BString destination) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_RENAME, FN_RENAME, null);
-        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_RENAME, origin.getValue(), destination.getValue());
         Object result = executeTwoPathAction(env, clientConnector, origin, destination, FtpAction.RENAME);
         if (result instanceof BError bError) {
             reportClientError(clientConnector, bError);
@@ -1120,8 +1096,6 @@ public class FtpClient {
     public static Object move(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_MOVE, FN_MOVE, null);
-        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_MOVE, sourcePath.getValue(), destinationPath.getValue());
         Object result = executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.RENAME);
         if (result instanceof BError bError) {
             reportClientError(clientConnector, bError);
@@ -1132,8 +1106,6 @@ public class FtpClient {
     public static Object copy(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_COPY, FN_COPY, null);
-        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_COPY, sourcePath.getValue(), destinationPath.getValue());
         Object result = executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.COPY);
         if (result instanceof BError bError) {
             reportClientError(clientConnector, bError);
@@ -1152,8 +1124,6 @@ public class FtpClient {
     public static Object rmdir(Environment env, BObject clientConnector, BString filePath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_RMDIR, FN_RMDIR, null);
-        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_RMDIR, filePath.getValue());
         Object result = executeSinglePathAction(env, clientConnector, filePath, FtpAction.RMDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -682,16 +682,16 @@ public class FtpClient {
         if (connector == null) {
             return null;
         }
+        Object error = null;
         try {
             connector.close();
         } catch (Exception exception) {
+            error = FtpUtil.createError(ON_CLOSE_ERROR + exception.getMessage(), exception, FTP_ERROR);
+        } finally {
             clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
             FtpMetricsUtil.reportConnectionClose(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT);
-            return FtpUtil.createError(ON_CLOSE_ERROR + exception.getMessage(), exception, FTP_ERROR);
         }
-        clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
-        FtpMetricsUtil.reportConnectionClose(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT);
-        return null;
+        return error;
     }
 
     /**
@@ -1010,7 +1010,7 @@ public class FtpClient {
 
     public static Object delete(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_DELETE, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.DELETE, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
@@ -1020,7 +1020,7 @@ public class FtpClient {
 
     public static Object isDirectory(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.ISDIR, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeIsDirectoryAction(remoteFileSystemBaseMessage, balFuture);
@@ -1030,7 +1030,7 @@ public class FtpClient {
 
     public static Object list(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.LIST, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeListAction(remoteFileSystemBaseMessage, balFuture);
@@ -1040,7 +1040,7 @@ public class FtpClient {
 
     public static Object mkdir(Environment env, BObject clientConnector, BString path) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MKDIR, path.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, path.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, path, FtpAction.MKDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
@@ -1050,7 +1050,7 @@ public class FtpClient {
 
     public static Object rename(Environment env, BObject clientConnector, BString origin, BString destination) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_RENAME,
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN,
                 origin.getValue(), destination.getValue());
         return sendTraces(
                 executeTwoPathAction(env, clientConnector, origin, destination, FtpAction.RENAME),
@@ -1059,7 +1059,7 @@ public class FtpClient {
 
     public static Object move(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MOVE,
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN,
                 sourcePath.getValue(), destinationPath.getValue());
         return sendTraces(
                 executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.RENAME),
@@ -1068,7 +1068,7 @@ public class FtpClient {
 
     public static Object copy(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_COPY,
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN,
                 sourcePath.getValue(), destinationPath.getValue());
         return sendTraces(
                 executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.COPY),
@@ -1077,7 +1077,7 @@ public class FtpClient {
 
     public static Object exists(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector,
                 filePath, FtpAction.EXISTS, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
@@ -1089,7 +1089,7 @@ public class FtpClient {
 
     public static Object rmdir(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_RMDIR, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.RMDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
@@ -1099,7 +1099,7 @@ public class FtpClient {
 
     public static Object size(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.SIZE, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeSizeAction(remoteFileSystemBaseMessage, balFuture);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -38,6 +38,9 @@ import io.ballerina.stdlib.ftp.client.circuitbreaker.CircuitBreakerConfig;
 import io.ballerina.stdlib.ftp.exception.BallerinaFtpException;
 import io.ballerina.stdlib.ftp.exception.FtpInvalidConfigException;
 import io.ballerina.stdlib.ftp.exception.RemoteFileSystemConnectorException;
+import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
+import io.ballerina.stdlib.ftp.observability.FtpObserverContext;
+import io.ballerina.stdlib.ftp.observability.FtpTracingUtil;
 import io.ballerina.stdlib.ftp.transport.RemoteFileSystemConnectorFactory;
 import io.ballerina.stdlib.ftp.transport.client.connector.contract.FtpAction;
 import io.ballerina.stdlib.ftp.transport.client.connector.contract.VfsClientConnector;
@@ -165,6 +168,31 @@ public class FtpClient {
         return null;
     }
 
+    private static String getRemoteUrl(BObject clientConnector) {
+        String host = (String) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_HOST);
+        if (host == null) {
+            return FtpMetricsUtil.UNKNOWN;
+        }
+        Object portObj = clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_PORT);
+        int port = portObj instanceof Integer ? (Integer) portObj : -1;
+        String protocol = getProtocol(clientConnector);
+        String hostPort = port > 0 ? host + ":" + port : host;
+        return FtpMetricsUtil.UNKNOWN.equals(protocol) ? hostPort : protocol + "://" + hostPort;
+    }
+
+    private static String getProtocol(BObject clientConnector) {
+        String protocol = (String) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_PROTOCOL);
+        return protocol != null ? protocol : FtpMetricsUtil.UNKNOWN;
+    }
+
+    private static void reportClientError(BObject clientConnector, BError bError) {
+        String errorType = bError.getType() != null
+                ? FtpMetricsUtil.toObservabilityErrorType(bError.getType().getName())
+                : FtpMetricsUtil.UNKNOWN;
+        FtpMetricsUtil.reportError(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.CONTEXT_CLIENT, errorType);
+    }
+
     public static Object initClientEndpoint(BObject clientEndpoint, BMap<Object, Object> config) {
         String protocol = extractProtocol(config);
         BError basicConfigError = configureClientEndpointBasic(clientEndpoint, config, protocol);
@@ -184,7 +212,15 @@ public class FtpClient {
             return vfsError;
         }
 
-        return createAndStoreConnector(clientEndpoint, ftpConfig, config);
+        Object result = createAndStoreConnector(clientEndpoint, ftpConfig, config);
+        if (result instanceof BError) {
+            FtpMetricsUtil.reportError(getRemoteUrl(clientEndpoint), getProtocol(clientEndpoint),
+                    FtpMetricsUtil.CONTEXT_CLIENT, FtpMetricsUtil.ERROR_TYPE_CONNECTION);
+        } else {
+            FtpMetricsUtil.reportNewConnection(getRemoteUrl(clientEndpoint), getProtocol(clientEndpoint),
+                    FtpMetricsUtil.CONTEXT_CLIENT);
+        }
+        return result;
     }
 
     private static String extractProtocol(BMap<Object, Object> config) {
@@ -449,7 +485,11 @@ public class FtpClient {
     }
 
     public static Object getBytes(Environment env, BObject clientConnector, BString filePath) {
-        return FtpRetryHelper.executeWithRetry(
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_GET);
+        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+        Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
@@ -461,10 +501,18 @@ public class FtpClient {
                 FtpConstants.OP_GET_BYTES,
                 filePath.getValue()
         );
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object getText(Environment env, BObject clientConnector, BString filePath) {
-        return FtpRetryHelper.executeWithRetry(
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_GET);
+        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+        Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
@@ -476,11 +524,19 @@ public class FtpClient {
                 FtpConstants.OP_GET_TEXT,
                 filePath.getValue()
         );
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object getJson(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_GET);
+        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
-        return FtpRetryHelper.executeWithRetry(
+        Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
@@ -493,11 +549,19 @@ public class FtpClient {
                 FtpConstants.OP_GET_JSON,
                 filePath.getValue()
         );
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object getXml(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_GET);
+        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
-        return FtpRetryHelper.executeWithRetry(
+        Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
@@ -510,13 +574,21 @@ public class FtpClient {
                 FtpConstants.OP_GET_XML,
                 filePath.getValue()
         );
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object getCsv(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_GET);
+        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         BMap<?, ?> csvFailSafe = (BMap<?, ?>) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_CSV_FAIL_SAFE);
         String fileNamePrefix = deriveFileNamePrefix(filePath);
-        return FtpRetryHelper.executeWithRetry(
+        Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
@@ -529,6 +601,10 @@ public class FtpClient {
                 FtpConstants.OP_GET_CSV,
                 filePath.getValue()
         );
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object getBytesAsStream(Environment env, BObject clientConnector, BString filePath) {
@@ -543,6 +619,10 @@ public class FtpClient {
             return cbError;
         }
 
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_GET);
+        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         return env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
@@ -553,8 +633,11 @@ public class FtpClient {
                                     balFuture, TypeCreator.createArrayType(PredefinedTypes.TYPE_BYTE), laxDataBinding));
             connector.addListener(connectorListener);
             connector.send(null, FtpAction.GET, filePath.getValue(), null);
-            Object result = getResult(balFuture);
-            return recordCircuitBreakerOutcome(clientConnector, result);
+            Object result = recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
+            if (result instanceof BError bError) {
+                reportClientError(clientConnector, bError);
+            }
+            return result;
         });
     }
 
@@ -571,6 +654,10 @@ public class FtpClient {
             return cbError;
         }
 
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_GET);
+        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         return env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
@@ -581,8 +668,11 @@ public class FtpClient {
                                     balFuture, typeDesc.getDescribingType(), laxDataBinding));
             connector.addListener(connectorListener);
             connector.send(null, FtpAction.GET, filePath.getValue(), null);
-            Object result = getResult(balFuture);
-            return recordCircuitBreakerOutcome(clientConnector, result);
+            Object result = recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
+            if (result instanceof BError bError) {
+                reportClientError(clientConnector, bError);
+            }
+            return result;
         });
     }
 
@@ -628,15 +718,20 @@ public class FtpClient {
     }
 
     public static Object close(BObject clientConnector) {
+        String url = getRemoteUrl(clientConnector);
+        String protocol = getProtocol(clientConnector);
         VfsClientConnectorImpl connector = (VfsClientConnectorImpl) clientConnector.getNativeData(VFS_CLIENT_CONNECTOR);
         if (connector != null) {
             try {
                 connector.close();
             } catch (Exception exception) {
+                FtpMetricsUtil.reportError(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT,
+                        FtpMetricsUtil.ERROR_TYPE_CLOSE);
                 return FtpUtil.createError(ON_CLOSE_ERROR + exception.getMessage(), exception, FTP_ERROR);
             }
         }
         clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
+        FtpMetricsUtil.reportConnectionClose(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT);
         return null;
     }
 
@@ -917,6 +1012,10 @@ public class FtpClient {
             return cbError;
         }
 
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_PUT);
+        FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         return env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
             CompletableFuture<Object> balFuture = new CompletableFuture<>();
@@ -929,17 +1028,28 @@ public class FtpClient {
             } else {
                 connector.send(message, FtpAction.APPEND, filePath, null);
             }
-            Object result = getResult(balFuture);
-            return recordCircuitBreakerOutcome(clientConnector, result);
+            Object result = recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
+            if (result instanceof BError bError) {
+                reportClientError(clientConnector, bError);
+            }
+            return result;
         });
     }
 
     public static Object delete(Environment env, BObject clientConnector, BString filePath) {
-        return executeSinglePathAction(env, clientConnector, filePath, FtpAction.DELETE, true,
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_DELETE);
+        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_DELETE, filePath.getValue());
+        Object result = executeSinglePathAction(env, clientConnector, filePath, FtpAction.DELETE, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
                     return true;
                 });
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object isDirectory(Environment env, BObject clientConnector, BString filePath) {
@@ -959,23 +1069,55 @@ public class FtpClient {
     }
 
     public static Object mkdir(Environment env, BObject clientConnector, BString path) {
-        return executeSinglePathAction(env, clientConnector, path, FtpAction.MKDIR, true,
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_MKDIR);
+        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_MKDIR, path.getValue());
+        Object result = executeSinglePathAction(env, clientConnector, path, FtpAction.MKDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
                     return true;
                 });
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object rename(Environment env, BObject clientConnector, BString origin, BString destination) {
-        return executeTwoPathAction(env, clientConnector, origin, destination, FtpAction.RENAME);
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_RENAME);
+        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_RENAME, origin.getValue(), destination.getValue());
+        Object result = executeTwoPathAction(env, clientConnector, origin, destination, FtpAction.RENAME);
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object move(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
-        return executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.RENAME);
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_MOVE);
+        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_MOVE, sourcePath.getValue(), destinationPath.getValue());
+        Object result = executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.RENAME);
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object copy(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
-        return executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.COPY);
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_COPY);
+        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_COPY, sourcePath.getValue(), destinationPath.getValue());
+        Object result = executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.COPY);
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object exists(Environment env, BObject clientConnector, BString filePath) {
@@ -987,11 +1129,19 @@ public class FtpClient {
     }
 
     public static Object rmdir(Environment env, BObject clientConnector, BString filePath) {
-        return executeSinglePathAction(env, clientConnector, filePath, FtpAction.RMDIR, true,
+        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_RMDIR);
+        FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
+                FtpMetricsUtil.OPERATION_TYPE_RMDIR, filePath.getValue());
+        Object result = executeSinglePathAction(env, clientConnector, filePath, FtpAction.RMDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
                     return true;
                 });
+        if (result instanceof BError bError) {
+            reportClientError(clientConnector, bError);
+        }
+        return result;
     }
 
     public static Object size(Environment env, BObject clientConnector, BString filePath) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -97,6 +97,27 @@ public class FtpClient {
     private static final Logger log = LoggerFactory.getLogger(FtpClient.class);
     private static final String CLIENT_CLOSED_ERROR_MESSAGE =
             "FTP Client is already closed, hence further operations are not allowed";
+
+    private static final String FN_GET_BYTES = "getBytes";
+    private static final String FN_GET_TEXT = "getText";
+    private static final String FN_GET_JSON = "getJson";
+    private static final String FN_GET_XML = "getXml";
+    private static final String FN_GET_CSV = "getCsv";
+    private static final String FN_GET_BYTES_AS_STREAM = "getBytesAsStream";
+    private static final String FN_GET_CSV_AS_STREAM = "getCsvAsStream";
+    private static final String FN_PUT_BYTES = "putBytes";
+    private static final String FN_PUT_TEXT = "putText";
+    private static final String FN_PUT_JSON = "putJson";
+    private static final String FN_PUT_XML = "putXml";
+    private static final String FN_PUT_CSV = "putCsv";
+    private static final String FN_PUT_BYTES_AS_STREAM = "putBytesAsStream";
+    private static final String FN_PUT_CSV_AS_STREAM = "putCsvAsStream";
+    private static final String FN_DELETE = "delete";
+    private static final String FN_MKDIR = "mkdir";
+    private static final String FN_RMDIR = "rmdir";
+    private static final String FN_RENAME = "rename";
+    private static final String FN_MOVE = "move";
+    private static final String FN_COPY = "copy";
     private static final String ON_CLOSE_ERROR = "Error occurred while closing the FTP client: ";
 
     private FtpClient() {
@@ -486,7 +507,7 @@ public class FtpClient {
 
     public static Object getBytes(Environment env, BObject clientConnector, BString filePath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET);
+                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_BYTES, null);
         FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         Object result = FtpRetryHelper.executeWithRetry(
@@ -509,7 +530,7 @@ public class FtpClient {
 
     public static Object getText(Environment env, BObject clientConnector, BString filePath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET);
+                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_TEXT, null);
         FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         Object result = FtpRetryHelper.executeWithRetry(
@@ -532,7 +553,7 @@ public class FtpClient {
 
     public static Object getJson(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET);
+                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_JSON, null);
         FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
@@ -557,7 +578,7 @@ public class FtpClient {
 
     public static Object getXml(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET);
+                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_XML, null);
         FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
@@ -582,7 +603,7 @@ public class FtpClient {
 
     public static Object getCsv(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET);
+                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_CSV, null);
         FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
@@ -620,7 +641,7 @@ public class FtpClient {
         }
 
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET);
+                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_BYTES_AS_STREAM, null);
         FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
@@ -655,7 +676,7 @@ public class FtpClient {
         }
 
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET);
+                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_CSV_AS_STREAM, null);
         FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
@@ -832,28 +853,28 @@ public class FtpClient {
                                   BString options) {
         InputStream stream = new ByteArrayInputStream(inputContent.getBytes());
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message);
+        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_BYTES);
     }
 
     public static Object putText(Environment env, BObject clientConnector, BString path, BString inputContent,
                                  BString options) {
         InputStream stream = new ByteArrayInputStream(inputContent.getValue().getBytes(StandardCharsets.UTF_8));
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message);
+        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_TEXT);
     }
 
     public static Object putJson(Environment env, BObject clientConnector, BString path, BString inputContent,
                                  BString options) {
         InputStream stream = new ByteArrayInputStream(inputContent.getValue().getBytes(StandardCharsets.UTF_8));
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message);
+        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_JSON);
     }
 
     public static Object putXml(Environment env, BObject clientConnector, BString path, BXml inputContent,
                                 BString options) {
         InputStream stream = new ByteArrayInputStream(inputContent.toString().getBytes(StandardCharsets.UTF_8));
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message);
+        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_XML);
     }
 
     public static Object putCsv(Environment env, BObject clientConnector, BString path, BArray inputContent,
@@ -862,7 +883,7 @@ public class FtpClient {
         String convertToCsv = CSVUtils.convertToCsv(inputContent, addHeader);
         InputStream stream = new ByteArrayInputStream(convertToCsv.getBytes(StandardCharsets.UTF_8));
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message);
+        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_CSV);
     }
 
     public static Object putBytesAsStream(Environment env, BObject clientConnector, BString path, BStream inputContent,
@@ -870,7 +891,7 @@ public class FtpClient {
         try {
             InputStream stream = createInputStreamFromIterator(env, inputContent.getIteratorObj());
             RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-            return putGenericAction(env, clientConnector, path, options, message);
+            return putGenericAction(env, clientConnector, path, options, message, FN_PUT_BYTES_AS_STREAM);
         } catch (Exception e) {
             return FtpUtil.createError(e.getMessage(), FTP_ERROR);
         }
@@ -881,7 +902,7 @@ public class FtpClient {
         try {
             InputStream stream = createInputStreamFromIterator(env, inputContent.getIteratorObj());
             RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-            return putGenericAction(env, clientConnector, path, options, message);
+            return putGenericAction(env, clientConnector, path, options, message, FN_PUT_CSV_AS_STREAM);
         } catch (Exception e) {
             return FtpUtil.createError(e.getMessage(), FTP_ERROR);
         }
@@ -999,7 +1020,7 @@ public class FtpClient {
     }
 
     private static Object putGenericAction(Environment env, BObject clientConnector, BString path, BString options,
-                                           RemoteFileSystemMessage message) {
+                                           RemoteFileSystemMessage message, String functionName) {
         VfsClientConnectorImpl connector = (VfsClientConnectorImpl) clientConnector.
                 getNativeData(VFS_CLIENT_CONNECTOR);
         if (connector == null) {
@@ -1013,7 +1034,7 @@ public class FtpClient {
         }
 
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_PUT);
+                FtpMetricsUtil.OPERATION_TYPE_PUT, functionName, null);
         FtpObserverContext spanCtx = FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         return env.yieldAndRun(() -> {
@@ -1038,7 +1059,7 @@ public class FtpClient {
 
     public static Object delete(Environment env, BObject clientConnector, BString filePath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_DELETE);
+                FtpMetricsUtil.OPERATION_TYPE_DELETE, FN_DELETE, null);
         FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_DELETE, filePath.getValue());
         Object result = executeSinglePathAction(env, clientConnector, filePath, FtpAction.DELETE, true,
@@ -1070,7 +1091,7 @@ public class FtpClient {
 
     public static Object mkdir(Environment env, BObject clientConnector, BString path) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_MKDIR);
+                FtpMetricsUtil.OPERATION_TYPE_MKDIR, FN_MKDIR, null);
         FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_MKDIR, path.getValue());
         Object result = executeSinglePathAction(env, clientConnector, path, FtpAction.MKDIR, true,
@@ -1086,7 +1107,7 @@ public class FtpClient {
 
     public static Object rename(Environment env, BObject clientConnector, BString origin, BString destination) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_RENAME);
+                FtpMetricsUtil.OPERATION_TYPE_RENAME, FN_RENAME, null);
         FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_RENAME, origin.getValue(), destination.getValue());
         Object result = executeTwoPathAction(env, clientConnector, origin, destination, FtpAction.RENAME);
@@ -1098,7 +1119,7 @@ public class FtpClient {
 
     public static Object move(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_MOVE);
+                FtpMetricsUtil.OPERATION_TYPE_MOVE, FN_MOVE, null);
         FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_MOVE, sourcePath.getValue(), destinationPath.getValue());
         Object result = executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.RENAME);
@@ -1110,7 +1131,7 @@ public class FtpClient {
 
     public static Object copy(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_COPY);
+                FtpMetricsUtil.OPERATION_TYPE_COPY, FN_COPY, null);
         FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_COPY, sourcePath.getValue(), destinationPath.getValue());
         Object result = executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.COPY);
@@ -1130,7 +1151,7 @@ public class FtpClient {
 
     public static Object rmdir(Environment env, BObject clientConnector, BString filePath) {
         FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_RMDIR);
+                FtpMetricsUtil.OPERATION_TYPE_RMDIR, FN_RMDIR, null);
         FtpTracingUtil.createClientSpanContext(getRemoteUrl(clientConnector), getProtocol(clientConnector),
                 FtpMetricsUtil.OPERATION_TYPE_RMDIR, filePath.getValue());
         Object result = executeSinglePathAction(env, clientConnector, filePath, FtpAction.RMDIR, true,

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -726,14 +726,16 @@ public class FtpClient {
         String url = getRemoteUrl(clientConnector);
         String protocol = getProtocol(clientConnector);
         VfsClientConnectorImpl connector = (VfsClientConnectorImpl) clientConnector.getNativeData(VFS_CLIENT_CONNECTOR);
-        if (connector != null) {
-            try {
-                connector.close();
-            } catch (Exception exception) {
-                FtpMetricsUtil.reportError(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT,
-                        FtpMetricsUtil.ERROR_TYPE_CLOSE);
-                return FtpUtil.createError(ON_CLOSE_ERROR + exception.getMessage(), exception, FTP_ERROR);
-            }
+        if (connector == null) {
+            return null;
+        }
+        try {
+            connector.close();
+        } catch (Exception exception) {
+            clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
+            FtpMetricsUtil.reportError(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT,
+                    FtpMetricsUtil.ERROR_TYPE_CLOSE);
+            return FtpUtil.createError(ON_CLOSE_ERROR + exception.getMessage(), exception, FTP_ERROR);
         }
         clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
         FtpMetricsUtil.reportConnectionClose(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -171,8 +171,7 @@ public class FtpClient {
 
     private static Object sendTraces(Object result, Environment env, BObject clientConnector) {
         if (result instanceof BError bError) {
-            String errorType = FtpMetricsUtil.toObservabilityErrorType(
-                    bError.getType() != null ? bError.getType().getName() : null);
+            String errorType = bError.getType() != null ? bError.getType().getName() : FtpMetricsUtil.UNKNOWN;
             FtpTracingUtil.sendErrorMetricsOnCurrentFrame(env, errorType);
         }
         return result;

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -98,6 +98,7 @@ public class FtpClient {
             "FTP Client is already closed, hence further operations are not allowed";
 
     private static final String ON_CLOSE_ERROR = "Error occurred while closing the FTP client: ";
+    private static final String REMOTE_URL = "remoteUrl";
 
     private FtpClient() {
         // private constructor
@@ -178,15 +179,7 @@ public class FtpClient {
     }
 
     private static String getRemoteUrl(BObject clientConnector) {
-        String host = (String) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_HOST);
-        if (host == null) {
-            return null;
-        }
-        Object portObj = clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_PORT);
-        int port = portObj instanceof Integer ? (Integer) portObj : -1;
-        String protocol = getProtocol(clientConnector);
-        String hostPort = port > 0 ? host + ":" + port : host;
-        return protocol != null ? protocol + "://" + hostPort : hostPort;
+        return (String) clientConnector.getNativeData(REMOTE_URL);
     }
 
     private static String getProtocol(BObject clientConnector) {
@@ -264,12 +257,14 @@ public class FtpClient {
                 authMap.get(FtpConstants.ENDPOINT_CONFIG_USERNAME));
         clientEndpoint.addNativeData(FtpConstants.ENDPOINT_CONFIG_PASS_KEY,
                 authMap.get(FtpConstants.ENDPOINT_CONFIG_PASS_KEY));
-        clientEndpoint.addNativeData(FtpConstants.ENDPOINT_CONFIG_HOST,
-                (config.getStringValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_HOST))).getValue());
-        clientEndpoint.addNativeData(FtpConstants.ENDPOINT_CONFIG_PORT,
-                FtpUtil.extractPortValue(config.getIntValue(StringUtils.fromString(
-                        FtpConstants.ENDPOINT_CONFIG_PORT))));
+        String host = (config.getStringValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_HOST))).getValue();
+        int port = FtpUtil.extractPortValue(config.getIntValue(StringUtils.fromString(
+                FtpConstants.ENDPOINT_CONFIG_PORT)));
+        clientEndpoint.addNativeData(FtpConstants.ENDPOINT_CONFIG_HOST, host);
+        clientEndpoint.addNativeData(FtpConstants.ENDPOINT_CONFIG_PORT, port);
         clientEndpoint.addNativeData(FtpConstants.ENDPOINT_CONFIG_PROTOCOL, protocol);
+        String hostPort = port > 0 ? host + ":" + port : host;
+        clientEndpoint.addNativeData(REMOTE_URL, protocol + "://" + hostPort);
         return null;
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -39,6 +39,7 @@ import io.ballerina.stdlib.ftp.exception.BallerinaFtpException;
 import io.ballerina.stdlib.ftp.exception.FtpInvalidConfigException;
 import io.ballerina.stdlib.ftp.exception.RemoteFileSystemConnectorException;
 import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
+import io.ballerina.stdlib.ftp.observability.FtpTracingUtil;
 import io.ballerina.stdlib.ftp.transport.RemoteFileSystemConnectorFactory;
 import io.ballerina.stdlib.ftp.transport.client.connector.contract.FtpAction;
 import io.ballerina.stdlib.ftp.transport.client.connector.contract.VfsClientConnector;
@@ -96,26 +97,6 @@ public class FtpClient {
     private static final String CLIENT_CLOSED_ERROR_MESSAGE =
             "FTP Client is already closed, hence further operations are not allowed";
 
-    private static final String FN_GET_BYTES = "getBytes";
-    private static final String FN_GET_TEXT = "getText";
-    private static final String FN_GET_JSON = "getJson";
-    private static final String FN_GET_XML = "getXml";
-    private static final String FN_GET_CSV = "getCsv";
-    private static final String FN_GET_BYTES_AS_STREAM = "getBytesAsStream";
-    private static final String FN_GET_CSV_AS_STREAM = "getCsvAsStream";
-    private static final String FN_PUT_BYTES = "putBytes";
-    private static final String FN_PUT_TEXT = "putText";
-    private static final String FN_PUT_JSON = "putJson";
-    private static final String FN_PUT_XML = "putXml";
-    private static final String FN_PUT_CSV = "putCsv";
-    private static final String FN_PUT_BYTES_AS_STREAM = "putBytesAsStream";
-    private static final String FN_PUT_CSV_AS_STREAM = "putCsvAsStream";
-    private static final String FN_DELETE = "delete";
-    private static final String FN_MKDIR = "mkdir";
-    private static final String FN_RMDIR = "rmdir";
-    private static final String FN_RENAME = "rename";
-    private static final String FN_MOVE = "move";
-    private static final String FN_COPY = "copy";
     private static final String ON_CLOSE_ERROR = "Error occurred while closing the FTP client: ";
 
     private FtpClient() {
@@ -187,29 +168,29 @@ public class FtpClient {
         return null;
     }
 
+    private static Object sendTraces(Object result, Environment env, BObject clientConnector) {
+        if (result instanceof BError bError) {
+            String errorType = FtpMetricsUtil.toObservabilityErrorType(
+                    bError.getType() != null ? bError.getType().getName() : null);
+            FtpTracingUtil.sendErrorMetricsOnCurrentFrame(env, errorType);
+        }
+        return result;
+    }
+
     private static String getRemoteUrl(BObject clientConnector) {
         String host = (String) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_HOST);
         if (host == null) {
-            return FtpMetricsUtil.UNKNOWN;
+            return null;
         }
         Object portObj = clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_PORT);
         int port = portObj instanceof Integer ? (Integer) portObj : -1;
         String protocol = getProtocol(clientConnector);
         String hostPort = port > 0 ? host + ":" + port : host;
-        return FtpMetricsUtil.UNKNOWN.equals(protocol) ? hostPort : protocol + "://" + hostPort;
+        return protocol != null ? protocol + "://" + hostPort : hostPort;
     }
 
     private static String getProtocol(BObject clientConnector) {
-        String protocol = (String) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_PROTOCOL);
-        return protocol != null ? protocol : FtpMetricsUtil.UNKNOWN;
-    }
-
-    private static void reportClientError(BObject clientConnector, BError bError) {
-        String errorType = bError.getType() != null
-                ? FtpMetricsUtil.toObservabilityErrorType(bError.getType().getName())
-                : FtpMetricsUtil.UNKNOWN;
-        FtpMetricsUtil.reportError(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.CONTEXT_CLIENT, errorType);
+        return (String) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_PROTOCOL);
     }
 
     public static Object initClientEndpoint(BObject clientEndpoint, BMap<Object, Object> config) {
@@ -232,10 +213,7 @@ public class FtpClient {
         }
 
         Object result = createAndStoreConnector(clientEndpoint, ftpConfig, config);
-        if (result instanceof BError) {
-            FtpMetricsUtil.reportError(getRemoteUrl(clientEndpoint), getProtocol(clientEndpoint),
-                    FtpMetricsUtil.CONTEXT_CLIENT, FtpMetricsUtil.ERROR_TYPE_CONNECTION);
-        } else {
+        if (!(result instanceof BError)) {
             FtpMetricsUtil.reportNewConnection(getRemoteUrl(clientEndpoint), getProtocol(clientEndpoint),
                     FtpMetricsUtil.CONTEXT_CLIENT);
         }
@@ -504,8 +482,8 @@ public class FtpClient {
     }
 
     public static Object getBytes(Environment env, BObject clientConnector, BString filePath) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_BYTES, null);
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
@@ -518,15 +496,12 @@ public class FtpClient {
                 FtpConstants.OP_GET_BYTES,
                 filePath.getValue()
         );
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+        return sendTraces(result, env, clientConnector);
     }
 
     public static Object getText(Environment env, BObject clientConnector, BString filePath) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_TEXT, null);
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
                 () -> {
@@ -539,15 +514,12 @@ public class FtpClient {
                 FtpConstants.OP_GET_TEXT,
                 filePath.getValue()
         );
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+        return sendTraces(result, env, clientConnector);
     }
 
     public static Object getJson(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_JSON, null);
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
@@ -562,15 +534,12 @@ public class FtpClient {
                 FtpConstants.OP_GET_JSON,
                 filePath.getValue()
         );
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+        return sendTraces(result, env, clientConnector);
     }
 
     public static Object getXml(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_XML, null);
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         Object result = FtpRetryHelper.executeWithRetry(
                 clientConnector,
@@ -585,15 +554,12 @@ public class FtpClient {
                 FtpConstants.OP_GET_XML,
                 filePath.getValue()
         );
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+        return sendTraces(result, env, clientConnector);
     }
 
     public static Object getCsv(Environment env, BObject clientConnector, BString filePath, BTypedesc typeDesc) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_CSV, null);
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
         BMap<?, ?> csvFailSafe = (BMap<?, ?>) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_CSV_FAIL_SAFE);
         String fileNamePrefix = deriveFileNamePrefix(filePath);
@@ -610,28 +576,26 @@ public class FtpClient {
                 FtpConstants.OP_GET_CSV,
                 filePath.getValue()
         );
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+        return sendTraces(result, env, clientConnector);
     }
 
     public static Object getBytesAsStream(Environment env, BObject clientConnector, BString filePath) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         VfsClientConnectorImpl connector = (VfsClientConnectorImpl) clientConnector.getNativeData(VFS_CLIENT_CONNECTOR);
         if (connector == null) {
-            return FtpUtil.createError(CLIENT_CLOSED_ERROR_MESSAGE, FTP_ERROR);
+            return sendTraces(FtpUtil.createError(CLIENT_CLOSED_ERROR_MESSAGE, FTP_ERROR),
+                    env, clientConnector);
         }
 
         // Check circuit breaker before proceeding
         BError cbError = getCircuitBreakerErrorIfOpen(clientConnector);
         if (cbError != null) {
-            return cbError;
+            return sendTraces(cbError, env, clientConnector);
         }
 
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_BYTES_AS_STREAM, null);
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
-        return env.yieldAndRun(() -> {
+        Object result = env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
             CompletableFuture<Object> balFuture = new CompletableFuture<>();
             FtpClientListener connectorListener = new FtpClientListener(balFuture, false,
@@ -640,31 +604,29 @@ public class FtpClient {
                                     balFuture, TypeCreator.createArrayType(PredefinedTypes.TYPE_BYTE), laxDataBinding));
             connector.addListener(connectorListener);
             connector.send(null, FtpAction.GET, filePath.getValue(), null);
-            Object result = recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
-            if (result instanceof BError bError) {
-                reportClientError(clientConnector, bError);
-            }
-            return result;
+            return recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
         });
+        return sendTraces(result, env, clientConnector);
     }
 
     public static Object getCsvAsStream(Environment env, BObject clientConnector, BString filePath,
                                         BTypedesc typeDesc) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
         VfsClientConnectorImpl connector = (VfsClientConnectorImpl) clientConnector.getNativeData(VFS_CLIENT_CONNECTOR);
         if (connector == null) {
-            return FtpUtil.createError(CLIENT_CLOSED_ERROR_MESSAGE, FTP_ERROR);
+            return sendTraces(FtpUtil.createError(CLIENT_CLOSED_ERROR_MESSAGE, FTP_ERROR),
+                    env, clientConnector);
         }
 
         // Check circuit breaker before proceeding
         BError cbError = getCircuitBreakerErrorIfOpen(clientConnector);
         if (cbError != null) {
-            return cbError;
+            return sendTraces(cbError, env, clientConnector);
         }
 
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_GET, FN_GET_CSV_AS_STREAM, null);
         boolean laxDataBinding = (boolean) clientConnector.getNativeData(FtpConstants.ENDPOINT_CONFIG_LAX_DATABINDING);
-        return env.yieldAndRun(() -> {
+        Object result = env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
             CompletableFuture<Object> balFuture = new CompletableFuture<>();
             FtpClientListener connectorListener = new FtpClientListener(balFuture, false,
@@ -673,12 +635,9 @@ public class FtpClient {
                                     balFuture, typeDesc.getDescribingType(), laxDataBinding));
             connector.addListener(connectorListener);
             connector.send(null, FtpAction.GET, filePath.getValue(), null);
-            Object result = recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
-            if (result instanceof BError bError) {
-                reportClientError(clientConnector, bError);
-            }
-            return result;
+            return recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
         });
+        return sendTraces(result, env, clientConnector);
     }
 
     private static Object getAllContent(Environment env, BObject clientConnector, BString filePath) {
@@ -713,8 +672,12 @@ public class FtpClient {
                 readInputStream.close();
                 clientObject.addNativeData(READ_INPUT_STREAM, null);
                 clientObject.addNativeData(ENTITY_BYTE_STREAM, null);
+                FtpMetricsUtil.reportConnectionClose(getRemoteUrl(clientObject), getProtocol(clientObject),
+                        FtpMetricsUtil.CONTEXT_CLIENT);
                 return null;
             } catch (IOException e) {
+                FtpMetricsUtil.reportConnectionClose(getRemoteUrl(clientObject), getProtocol(clientObject),
+                        FtpMetricsUtil.CONTEXT_CLIENT);
                 return IOUtils.createError(e);
             }
         } else {
@@ -733,8 +696,7 @@ public class FtpClient {
             connector.close();
         } catch (Exception exception) {
             clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
-            FtpMetricsUtil.reportError(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT,
-                    FtpMetricsUtil.ERROR_TYPE_CLOSE);
+            FtpMetricsUtil.reportConnectionClose(url, protocol, FtpMetricsUtil.CONTEXT_CLIENT);
             return FtpUtil.createError(ON_CLOSE_ERROR + exception.getMessage(), exception, FTP_ERROR);
         }
         clientConnector.addNativeData(VFS_CLIENT_CONNECTOR, null);
@@ -837,60 +799,81 @@ public class FtpClient {
 
     public static Object putBytes(Environment env, BObject clientConnector, BString path, BArray inputContent,
                                   BString options) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         InputStream stream = new ByteArrayInputStream(inputContent.getBytes());
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_BYTES);
+        return sendTraces(putGenericAction(env, clientConnector, path, options, message),
+                env, clientConnector);
     }
 
     public static Object putText(Environment env, BObject clientConnector, BString path, BString inputContent,
                                  BString options) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         InputStream stream = new ByteArrayInputStream(inputContent.getValue().getBytes(StandardCharsets.UTF_8));
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_TEXT);
+        return sendTraces(putGenericAction(env, clientConnector, path, options, message),
+                env, clientConnector);
     }
 
     public static Object putJson(Environment env, BObject clientConnector, BString path, BString inputContent,
                                  BString options) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         InputStream stream = new ByteArrayInputStream(inputContent.getValue().getBytes(StandardCharsets.UTF_8));
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_JSON);
+        return sendTraces(putGenericAction(env, clientConnector, path, options, message),
+                env, clientConnector);
     }
 
     public static Object putXml(Environment env, BObject clientConnector, BString path, BXml inputContent,
                                 BString options) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         InputStream stream = new ByteArrayInputStream(inputContent.toString().getBytes(StandardCharsets.UTF_8));
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_XML);
+        return sendTraces(putGenericAction(env, clientConnector, path, options, message),
+                env, clientConnector);
     }
 
     public static Object putCsv(Environment env, BObject clientConnector, BString path, BArray inputContent,
                                 BString options) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         boolean addHeader = !options.getValue().equals(FtpConstants.WRITE_OPTION_APPEND);
         String convertToCsv = CSVUtils.convertToCsv(inputContent, addHeader);
         InputStream stream = new ByteArrayInputStream(convertToCsv.getBytes(StandardCharsets.UTF_8));
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-        return putGenericAction(env, clientConnector, path, options, message, FN_PUT_CSV);
+        return sendTraces(putGenericAction(env, clientConnector, path, options, message),
+                env, clientConnector);
     }
 
     public static Object putBytesAsStream(Environment env, BObject clientConnector, BString path, BStream inputContent,
                                           BString options) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         try {
             InputStream stream = createInputStreamFromIterator(env, inputContent.getIteratorObj());
             RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-            return putGenericAction(env, clientConnector, path, options, message, FN_PUT_BYTES_AS_STREAM);
+            return sendTraces(putGenericAction(env, clientConnector, path, options, message),
+                    env, clientConnector);
         } catch (Exception e) {
-            return FtpUtil.createError(e.getMessage(), FTP_ERROR);
+            return sendTraces(FtpUtil.createError(e.getMessage(), FTP_ERROR), env, clientConnector);
         }
     }
 
     public static Object putCsvAsStream(Environment env, BObject clientConnector, BString path, BStream inputContent,
                                         BString options) {
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         try {
             InputStream stream = createInputStreamFromIterator(env, inputContent.getIteratorObj());
             RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
-            return putGenericAction(env, clientConnector, path, options, message, FN_PUT_CSV_AS_STREAM);
+            return sendTraces(putGenericAction(env, clientConnector, path, options, message),
+                    env, clientConnector);
         } catch (Exception e) {
-            return FtpUtil.createError(e.getMessage(), FTP_ERROR);
+            return sendTraces(FtpUtil.createError(e.getMessage(), FTP_ERROR), env, clientConnector);
         }
     }
 
@@ -1006,7 +989,7 @@ public class FtpClient {
     }
 
     private static Object putGenericAction(Environment env, BObject clientConnector, BString path, BString options,
-                                           RemoteFileSystemMessage message, String functionName) {
+                                           RemoteFileSystemMessage message) {
         VfsClientConnectorImpl connector = (VfsClientConnectorImpl) clientConnector.
                 getNativeData(VFS_CLIENT_CONNECTOR);
         if (connector == null) {
@@ -1019,8 +1002,6 @@ public class FtpClient {
             return cbError;
         }
 
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_PUT, functionName, null);
         return env.yieldAndRun(() -> {
             recordCircuitBreakerRequestStart(clientConnector);
             CompletableFuture<Object> balFuture = new CompletableFuture<>();
@@ -1033,116 +1014,107 @@ public class FtpClient {
             } else {
                 connector.send(message, FtpAction.APPEND, filePath, null);
             }
-            Object result = recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
-            if (result instanceof BError bError) {
-                reportClientError(clientConnector, bError);
-            }
-            return result;
+            return recordCircuitBreakerOutcome(clientConnector, getResult(balFuture));
         });
     }
 
     public static Object delete(Environment env, BObject clientConnector, BString filePath) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_DELETE, FN_DELETE, null);
-        Object result = executeSinglePathAction(env, clientConnector, filePath, FtpAction.DELETE, true,
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_DELETE, filePath.getValue());
+        return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.DELETE, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
                     return true;
-                });
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+                }), env, clientConnector);
     }
 
     public static Object isDirectory(Environment env, BObject clientConnector, BString filePath) {
-        return executeSinglePathAction(env, clientConnector, filePath, FtpAction.ISDIR, false,
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+        return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.ISDIR, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeIsDirectoryAction(remoteFileSystemBaseMessage, balFuture);
                     return true;
-                });
+                }), env, clientConnector);
     }
 
     public static Object list(Environment env, BObject clientConnector, BString filePath) {
-        return executeSinglePathAction(env, clientConnector, filePath, FtpAction.LIST, false,
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+        return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.LIST, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeListAction(remoteFileSystemBaseMessage, balFuture);
                     return true;
-                });
+                }), env, clientConnector);
     }
 
     public static Object mkdir(Environment env, BObject clientConnector, BString path) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_MKDIR, FN_MKDIR, null);
-        Object result = executeSinglePathAction(env, clientConnector, path, FtpAction.MKDIR, true,
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MKDIR, path.getValue());
+        return sendTraces(executeSinglePathAction(env, clientConnector, path, FtpAction.MKDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
                     return true;
-                });
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+                }), env, clientConnector);
     }
 
     public static Object rename(Environment env, BObject clientConnector, BString origin, BString destination) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_RENAME, FN_RENAME, null);
-        Object result = executeTwoPathAction(env, clientConnector, origin, destination, FtpAction.RENAME);
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_RENAME,
+                origin.getValue(), destination.getValue());
+        return sendTraces(
+                executeTwoPathAction(env, clientConnector, origin, destination, FtpAction.RENAME),
+                env, clientConnector);
     }
 
     public static Object move(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_MOVE, FN_MOVE, null);
-        Object result = executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.RENAME);
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MOVE,
+                sourcePath.getValue(), destinationPath.getValue());
+        return sendTraces(
+                executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.RENAME),
+                env, clientConnector);
     }
 
     public static Object copy(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_COPY, FN_COPY, null);
-        Object result = executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.COPY);
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_COPY,
+                sourcePath.getValue(), destinationPath.getValue());
+        return sendTraces(
+                executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.COPY),
+                env, clientConnector);
     }
 
     public static Object exists(Environment env, BObject clientConnector, BString filePath) {
-        return executeSinglePathAction(env, clientConnector, filePath, FtpAction.EXISTS, false,
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+        return sendTraces(executeSinglePathAction(env, clientConnector,
+                filePath, FtpAction.EXISTS, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeExistsAction(remoteFileSystemBaseMessage, balFuture);
                     return true;
-                });
+                }), env, clientConnector
+        );
     }
 
     public static Object rmdir(Environment env, BObject clientConnector, BString filePath) {
-        FtpMetricsUtil.reportFileOperation(getRemoteUrl(clientConnector), getProtocol(clientConnector),
-                FtpMetricsUtil.OPERATION_TYPE_RMDIR, FN_RMDIR, null);
-        Object result = executeSinglePathAction(env, clientConnector, filePath, FtpAction.RMDIR, true,
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_RMDIR, filePath.getValue());
+        return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.RMDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
                     return true;
-                });
-        if (result instanceof BError bError) {
-            reportClientError(clientConnector, bError);
-        }
-        return result;
+                }), env, clientConnector);
     }
 
     public static Object size(Environment env, BObject clientConnector, BString filePath) {
-        return executeSinglePathAction(env, clientConnector, filePath, FtpAction.SIZE, false,
+        FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_GET, filePath.getValue());
+        return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.SIZE, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeSizeAction(remoteFileSystemBaseMessage, balFuture);
                     return true;
-                });
+                }), env, clientConnector);
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
@@ -56,23 +56,15 @@ public class FtpMetricsUtil {
     /** Event-type tag value: content-binding error dispatched to {@code onError}. */
     public static final String EVENT_TYPE_ERROR = "error";
 
-    /** Operation-type tag value: get file content ({@code ftp:Client.getBytes()} and typed variants). */
+    /** Operation-type tag value: read file content ({@code getBytes}, typed and streaming variants). */
     public static final String OPERATION_TYPE_GET = "get";
 
-    /** Operation-type tag value: put file content ({@code ftp:Client.putBytes()} and typed variants). */
+    /** Operation-type tag value: write file content ({@code putBytes}, typed and streaming variants). */
     public static final String OPERATION_TYPE_PUT = "put";
 
-    /** Operation-type tag value: {@code ftp:Client.delete()}. */
-    public static final String OPERATION_TYPE_DELETE = "delete";
-    public static final String OPERATION_TYPE_RENAME = "rename";
-    public static final String OPERATION_TYPE_MOVE = "move";
-    public static final String OPERATION_TYPE_COPY = "copy";
-
-    /** Operation-type tag value: {@code ftp:Client.mkdir()}. */
-    public static final String OPERATION_TYPE_MKDIR = "mkdir";
-
-    /** Operation-type tag value: {@code ftp:Client.rmdir()}. */
-    public static final String OPERATION_TYPE_RMDIR = "rmdir";
+    /** Operation-type tag value: admin/filesystem operations ({@code delete}, {@code rename}, {@code move},
+     *  {@code copy}, {@code mkdir}, {@code rmdir}, {@code isDirectory}, {@code list}, {@code exists}, {@code size}). */
+    public static final String OPERATION_TYPE_ADMIN = "admin";
 
     /** Action-type tag value for FTP client operations (get, put, delete, etc.). */
     public static final String ACTION_TYPE_OPERATION = "operation";
@@ -129,17 +121,11 @@ public class FtpMetricsUtil {
     }
 
     private static void incrementGauge(FtpObserverContext observerContext, String name, String desc) {
-        if (metricRegistry == null) {
-            return;
-        }
         metricRegistry.gauge(new MetricId(CONNECTOR_NAME + "_" + name, desc, observerContext.getAllTags()))
                 .increment();
     }
 
     private static void decrementGauge(FtpObserverContext observerContext, String name, String desc) {
-        if (metricRegistry == null) {
-            return;
-        }
         metricRegistry.gauge(new MetricId(CONNECTOR_NAME + "_" + name, desc, observerContext.getAllTags()))
                 .decrement();
     }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
@@ -22,7 +22,6 @@ import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.metrics.DefaultMetricRegistry;
 import io.ballerina.runtime.observability.metrics.MetricId;
 import io.ballerina.runtime.observability.metrics.MetricRegistry;
-import io.ballerina.stdlib.ftp.util.FtpUtil;
 
 import java.net.InetAddress;
 
@@ -81,36 +80,6 @@ public class FtpMetricsUtil {
     /** Action-type tag value for FTP listener event dispatches (create, delete, error). */
     public static final String ACTION_TYPE_EVENT = "event";
 
-    /** Error-type tag value: connection-level failure. */
-    public static final String ERROR_TYPE_CONNECTION = "connection";
-
-    /** Error-type tag value: authentication failure. */
-    public static final String ERROR_TYPE_AUTHENTICATION = "authentication";
-
-    /** Error-type tag value: file not found. */
-    public static final String ERROR_TYPE_FILE_NOT_FOUND = "file_not_found";
-
-    /** Error-type tag value: file already exists. */
-    public static final String ERROR_TYPE_FILE_ALREADY_EXISTS = "file_already_exists";
-
-    /** Error-type tag value: remote service unavailable (e.g. circuit-breaker open). */
-    public static final String ERROR_TYPE_SERVICE_UNAVAILABLE = "service_unavailable";
-
-    /** Error-type tag value: content binding / deserialization failure. */
-    public static final String ERROR_TYPE_CONTENT_BINDING = "content_binding";
-
-    /** Error-type tag value: all retry attempts exhausted. */
-    public static final String ERROR_TYPE_RETRY_EXHAUSTED = "retry_exhausted";
-
-    /** Error-type tag value: circuit breaker is open. */
-    public static final String ERROR_TYPE_CIRCUIT_BREAKER_OPEN = "circuit_breaker_open";
-
-    /** Error-type tag value: invalid configuration. */
-    public static final String ERROR_TYPE_INVALID_CONFIG = "invalid_config";
-
-    /** Error-type tag value: error while closing a connection. */
-    public static final String ERROR_TYPE_CLOSE = "close";
-
     private static final MetricRegistry metricRegistry = DefaultMetricRegistry.getInstance();
 
     private static String instanceUrl;
@@ -157,41 +126,6 @@ public class FtpMetricsUtil {
         }
         FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
         decrementGauge(observerContext, METRIC_ACTIVE_CONNECTIONS[0], METRIC_ACTIVE_CONNECTIONS[1]);
-    }
-
-    /**
-     * Maps a raw {@link Throwable} to an observability error-type constant.
-     *
-     * @param throwable the exception to classify
-     * @return the matching {@code ERROR_TYPE_*} string
-     */
-    public static String toObservabilityErrorType(Throwable throwable) {
-        return toObservabilityErrorType(FtpUtil.getErrorTypeForException(throwable));
-    }
-
-    /**
-     * Maps a Ballerina FTP error type name to its observability constant.
-     *
-     * @param ballerinaErrorType the {@code error.getType().getName()} value
-     * @return the matching {@code ERROR_TYPE_*} string
-     */
-    public static String toObservabilityErrorType(String ballerinaErrorType) {
-        if (ballerinaErrorType == null) {
-            return UNKNOWN;
-        }
-        return switch (ballerinaErrorType) {
-            case "ConnectionError" -> ERROR_TYPE_CONNECTION;
-            case "AuthenticationError" -> ERROR_TYPE_AUTHENTICATION;
-            case "FileNotFoundError" -> ERROR_TYPE_FILE_NOT_FOUND;
-            case "FileAlreadyExistsError" -> ERROR_TYPE_FILE_ALREADY_EXISTS;
-            case "ServiceUnavailableError" -> ERROR_TYPE_SERVICE_UNAVAILABLE;
-            case "ContentBindingError" -> ERROR_TYPE_CONTENT_BINDING;
-            case "RetryError" -> ERROR_TYPE_RETRY_EXHAUSTED;
-            case "CircuitBreakerOpenError" -> ERROR_TYPE_CIRCUIT_BREAKER_OPEN;
-            case "InvalidConfigError" -> ERROR_TYPE_INVALID_CONFIG;
-            case "CloseError" -> ERROR_TYPE_CLOSE;
-            default -> UNKNOWN;
-        };
     }
 
     private static void incrementGauge(FtpObserverContext observerContext, String name, String desc) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
@@ -113,15 +113,20 @@ public class FtpMetricsUtil {
 
     private static final MetricRegistry metricRegistry = DefaultMetricRegistry.getInstance();
 
-    /** Cached hostname of the current instance, resolved once at class load time. */
-    public static final String INSTANCE_URL = resolveInstanceUrl();
+    private static String instanceUrl;
+    private static boolean instanceUrlResolved;
 
-    private static String resolveInstanceUrl() {
-        try {
-            return InetAddress.getLocalHost().getHostName();
-        } catch (Exception e) {
-            return UNKNOWN;
+    /** Returns the hostname of the current instance, resolved lazily on first use, or {@code null} if unavailable. */
+    public static String getInstanceUrl() {
+        if (!instanceUrlResolved) {
+            try {
+                instanceUrl = InetAddress.getLocalHost().getHostName();
+            } catch (Exception e) {
+                instanceUrl = null;
+            }
+            instanceUrlResolved = true;
         }
+        return instanceUrl;
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
@@ -48,8 +48,8 @@ public class FtpMetricsUtil {
     /** Context tag value for FTP listener operations. */
     public static final String CONTEXT_LISTENER = "listener";
 
-    /** Event-type tag value: a file was added or changed. */
-    public static final String EVENT_TYPE_CHANGE = "change";
+    /** Event-type tag value: a file was added or created. */
+    public static final String EVENT_TYPE_CHANGE = "create";
 
     /** Event-type tag value: a file was deleted. */
     public static final String EVENT_TYPE_DELETE = "delete";
@@ -78,7 +78,7 @@ public class FtpMetricsUtil {
     /** Action-type tag value for FTP client operations (get, put, delete, etc.). */
     public static final String ACTION_TYPE_OPERATION = "operation";
 
-    /** Action-type tag value for FTP listener event dispatches (change, delete, error). */
+    /** Action-type tag value for FTP listener event dispatches (create, delete, error). */
     public static final String ACTION_TYPE_EVENT = "event";
 
     /** Error-type tag value: connection-level failure. */

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.ftp.observability;
+
+import io.ballerina.runtime.observability.ObserveUtils;
+import io.ballerina.runtime.observability.metrics.DefaultMetricRegistry;
+import io.ballerina.runtime.observability.metrics.MetricId;
+import io.ballerina.runtime.observability.metrics.MetricRegistry;
+import io.ballerina.stdlib.ftp.util.FtpUtil;
+
+/**
+ * Utility class for recording FTP connector metrics.
+ *
+ * <p>Metrics published:
+ * <ul>
+ *   <li>{@code ftp_active_connections} (gauge) — active FTP/FTPS/SFTP connections</li>
+ *   <li>{@code ftp_file_operations} (counter) — client file operations</li>
+ *   <li>{@code ftp_file_events} (counter) — listener file events</li>
+ *   <li>{@code ftp_errors} (counter) — errors by type</li>
+ * </ul>
+ */
+public class FtpMetricsUtil {
+    private static final String CONNECTOR_NAME = "ftp";
+    private static final String[] METRIC_ACTIVE_CONNECTIONS = {
+            "active_connections", "Number of active FTP/FTPS/SFTP connections"};
+    private static final String[] METRIC_FILE_OPERATIONS = {
+            "file_operations", "Number of file operations performed"};
+    private static final String[] METRIC_FILE_EVENTS = {
+            "file_events", "Number of file events dispatched by the listener"};
+    private static final String[] METRIC_ERRORS = {
+            "errors", "Number of errors"};
+
+    /** Sentinel used when a URL or protocol value is unavailable. */
+    public static final String UNKNOWN = "unknown";
+
+    /** Context tag value for FTP client operations. */
+    public static final String CONTEXT_CLIENT = "client";
+
+    /** Context tag value for FTP listener operations. */
+    public static final String CONTEXT_LISTENER = "listener";
+
+    /** Event-type tag value: a file was added or changed. */
+    public static final String EVENT_TYPE_CHANGE = "change";
+
+    /** Event-type tag value: a file was deleted. */
+    public static final String EVENT_TYPE_DELETE = "delete";
+
+    /** Event-type tag value: content-binding error dispatched to {@code onError}. */
+    public static final String EVENT_TYPE_ERROR = "error";
+
+    /** Operation-type tag value: get file content ({@code ftp:Client.getBytes()} and typed variants). */
+    public static final String OPERATION_TYPE_GET = "get";
+
+    /** Operation-type tag value: put file content ({@code ftp:Client.putBytes()} and typed variants). */
+    public static final String OPERATION_TYPE_PUT = "put";
+
+    /** Operation-type tag value: {@code ftp:Client.delete()}. */
+    public static final String OPERATION_TYPE_DELETE = "delete";
+    public static final String OPERATION_TYPE_RENAME = "rename";
+    public static final String OPERATION_TYPE_MOVE = "move";
+    public static final String OPERATION_TYPE_COPY = "copy";
+
+    /** Operation-type tag value: {@code ftp:Client.mkdir()}. */
+    public static final String OPERATION_TYPE_MKDIR = "mkdir";
+
+    /** Operation-type tag value: {@code ftp:Client.rmdir()}. */
+    public static final String OPERATION_TYPE_RMDIR = "rmdir";
+
+    /** Error-type tag value: connection-level failure. */
+    public static final String ERROR_TYPE_CONNECTION = "connection";
+
+    /** Error-type tag value: authentication failure. */
+    public static final String ERROR_TYPE_AUTHENTICATION = "authentication";
+
+    /** Error-type tag value: file not found. */
+    public static final String ERROR_TYPE_FILE_NOT_FOUND = "file_not_found";
+
+    /** Error-type tag value: file already exists. */
+    public static final String ERROR_TYPE_FILE_ALREADY_EXISTS = "file_already_exists";
+
+    /** Error-type tag value: remote service unavailable (e.g. circuit-breaker open). */
+    public static final String ERROR_TYPE_SERVICE_UNAVAILABLE = "service_unavailable";
+
+    /** Error-type tag value: content binding / deserialization failure. */
+    public static final String ERROR_TYPE_CONTENT_BINDING = "content_binding";
+
+    /** Error-type tag value: all retry attempts exhausted. */
+    public static final String ERROR_TYPE_RETRY_EXHAUSTED = "retry_exhausted";
+
+    /** Error-type tag value: circuit breaker is open. */
+    public static final String ERROR_TYPE_CIRCUIT_BREAKER_OPEN = "circuit_breaker_open";
+
+    /** Error-type tag value: invalid configuration. */
+    public static final String ERROR_TYPE_INVALID_CONFIG = "invalid_config";
+
+    /** Error-type tag value: error while closing a connection. */
+    public static final String ERROR_TYPE_CLOSE = "close";
+
+    private static final MetricRegistry metricRegistry = DefaultMetricRegistry.getInstance();
+
+    /**
+     * Increments the active-connections gauge when a new FTP client or listener is created.
+     *
+     * @param url      host:port of the remote server
+     * @param protocol "ftp", "ftps", or "sftp"
+     * @param context  {@link #CONTEXT_CLIENT} or {@link #CONTEXT_LISTENER}
+     */
+    public static void reportNewConnection(String url, String protocol, String context) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+        incrementGauge(observerContext, METRIC_ACTIVE_CONNECTIONS[0], METRIC_ACTIVE_CONNECTIONS[1]);
+    }
+
+    /**
+     * Decrements the active-connections gauge when an FTP client or listener is closed.
+     *
+     * @param url      host:port of the remote server
+     * @param protocol "ftp", "ftps", or "sftp"
+     * @param context  client or listener
+     */
+    public static void reportConnectionClose(String url, String protocol, String context) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+        decrementGauge(observerContext, METRIC_ACTIVE_CONNECTIONS[0], METRIC_ACTIVE_CONNECTIONS[1]);
+    }
+
+    /**
+     * Increments the file-operations counter for any client operation.
+     * File paths are intentionally excluded to avoid unbounded metric cardinality;
+     * they are captured instead as tags on the trace span context.
+     *
+     * @param url           remote URL
+     * @param protocol      protocol string
+     * @param operationType one of the {@code OPERATION_TYPE_*} constants
+     */
+    public static void reportFileOperation(String url, String protocol, String operationType) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_CLIENT, url, protocol);
+        observerContext.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
+        incrementCounter(observerContext, METRIC_FILE_OPERATIONS[0], METRIC_FILE_OPERATIONS[1]);
+    }
+
+    /**
+     * Increments the file-events counter when the listener dispatches a resource method.
+     * File paths are excluded from the counter to avoid unbounded cardinality;
+     * they are captured on the trace span context instead.
+     *
+     * @param url       remote URL
+     * @param protocol  protocol string
+     * @param eventType {@link #EVENT_TYPE_CHANGE}, {@link #EVENT_TYPE_DELETE}, or {@link #EVENT_TYPE_ERROR}
+     */
+    public static void reportFileEvent(String url, String protocol, String eventType) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_LISTENER, url, protocol);
+        observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
+        incrementCounter(observerContext, METRIC_FILE_EVENTS[0], METRIC_FILE_EVENTS[1]);
+    }
+
+    /**
+     * Increments the errors counter.
+     *
+     * @param url       host:port
+     * @param protocol  protocol string
+     * @param context   client or listener
+     * @param errorType one of the {@code ERROR_TYPE_*} constants
+     */
+    public static void reportError(String url, String protocol, String context, String errorType) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+        observerContext.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
+        incrementCounter(observerContext, METRIC_ERRORS[0], METRIC_ERRORS[1]);
+    }
+
+    /**
+     * Maps a raw {@link Throwable} (e.g. from {@code RemoteFileSystemListener.onError})
+     * directly to an observability error-type constant, eliminating the need for callers
+     * to pass through {@code FtpUtil.getErrorTypeForException} first.
+     *
+     * @param throwable the exception to classify
+     * @return the matching {@code ERROR_TYPE_*} string
+     */
+    public static String toObservabilityErrorType(Throwable throwable) {
+        return toObservabilityErrorType(FtpUtil.getErrorTypeForException(throwable));
+    }
+
+    /**
+     * Maps a Ballerina FTP error type name to its observability constant.
+     *
+     * @param ballerinaErrorType the {@code error.getType().getName()} value
+     * @return the matching {@code ERROR_TYPE_*} string
+     */
+    public static String toObservabilityErrorType(String ballerinaErrorType) {
+        if (ballerinaErrorType == null) {
+            return UNKNOWN;
+        }
+        return switch (ballerinaErrorType) {
+            case "ConnectionError" -> ERROR_TYPE_CONNECTION;
+            case "AuthenticationError" -> ERROR_TYPE_AUTHENTICATION;
+            case "FileNotFoundError" -> ERROR_TYPE_FILE_NOT_FOUND;
+            case "FileAlreadyExistsError" -> ERROR_TYPE_FILE_ALREADY_EXISTS;
+            case "ServiceUnavailableError" -> ERROR_TYPE_SERVICE_UNAVAILABLE;
+            case "ContentBindingError" -> ERROR_TYPE_CONTENT_BINDING;
+            case "RetryError" -> ERROR_TYPE_RETRY_EXHAUSTED;
+            case "CircuitBreakerOpenError" -> ERROR_TYPE_CIRCUIT_BREAKER_OPEN;
+            case "InvalidConfigError" -> ERROR_TYPE_INVALID_CONFIG;
+            default -> UNKNOWN;
+        };
+    }
+
+    private static void incrementCounter(FtpObserverContext observerContext, String name, String desc) {
+        if (metricRegistry == null) {
+            return;
+        }
+        metricRegistry.counter(new MetricId(CONNECTOR_NAME + "_" + name, desc, observerContext.getAllTags()))
+                .increment();
+    }
+
+    private static void incrementGauge(FtpObserverContext observerContext, String name, String desc) {
+        if (metricRegistry == null) {
+            return;
+        }
+        metricRegistry.gauge(new MetricId(CONNECTOR_NAME + "_" + name, desc, observerContext.getAllTags()))
+                .increment();
+    }
+
+    private static void decrementGauge(FtpObserverContext observerContext, String name, String desc) {
+        if (metricRegistry == null) {
+            return;
+        }
+        metricRegistry.gauge(new MetricId(CONNECTOR_NAME + "_" + name, desc, observerContext.getAllTags()))
+                .decrement();
+    }
+
+    private FtpMetricsUtil() {
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
@@ -24,6 +24,8 @@ import io.ballerina.runtime.observability.metrics.MetricId;
 import io.ballerina.runtime.observability.metrics.MetricRegistry;
 import io.ballerina.stdlib.ftp.util.FtpUtil;
 
+import java.net.InetAddress;
+
 /**
  * Utility class for recording FTP connector metrics.
  *
@@ -114,6 +116,17 @@ public class FtpMetricsUtil {
 
     private static final MetricRegistry metricRegistry = DefaultMetricRegistry.getInstance();
 
+    /** Cached hostname of the current instance, resolved once at class load time. */
+    public static final String INSTANCE_URL = resolveInstanceUrl();
+
+    private static String resolveInstanceUrl() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (Exception e) {
+            return UNKNOWN;
+        }
+    }
+
     /**
      * Increments the active-connections gauge when a new FTP client or listener is created.
      *
@@ -149,16 +162,26 @@ public class FtpMetricsUtil {
      * File paths are intentionally excluded to avoid unbounded metric cardinality;
      * they are captured instead as tags on the trace span context.
      *
-     * @param url           remote URL
-     * @param protocol      protocol string
-     * @param operationType one of the {@code OPERATION_TYPE_*} constants
+     * @param url               remote URL
+     * @param protocol          protocol string
+     * @param operationType     one of the {@code OPERATION_TYPE_*} constants
+     * @param functionName      the Ballerina client function name (e.g. {@code "getBytes"})
+     * @param entryFunctionName the entry-point Ballerina function name, or {@link #UNKNOWN}
      */
-    public static void reportFileOperation(String url, String protocol, String operationType) {
+    public static void reportFileOperation(String url, String protocol, String operationType,
+                                           String functionName, String entryFunctionName) {
         if (!ObserveUtils.isMetricsEnabled()) {
             return;
         }
         FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_CLIENT, url, protocol);
         observerContext.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
+        if (functionName != null) {
+            observerContext.addTag(FtpObserverContext.TAG_FUNCTION_NAME, functionName);
+        }
+        if (entryFunctionName != null) {
+            observerContext.addTag(FtpObserverContext.TAG_ENTRY_FUNCTION_NAME, entryFunctionName);
+        }
+        observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, INSTANCE_URL);
         incrementCounter(observerContext, METRIC_FILE_OPERATIONS[0], METRIC_FILE_OPERATIONS[1]);
     }
 
@@ -167,16 +190,26 @@ public class FtpMetricsUtil {
      * File paths are excluded from the counter to avoid unbounded cardinality;
      * they are captured on the trace span context instead.
      *
-     * @param url       remote URL
-     * @param protocol  protocol string
-     * @param eventType {@link #EVENT_TYPE_CHANGE}, {@link #EVENT_TYPE_DELETE}, or {@link #EVENT_TYPE_ERROR}
+     * @param url               remote URL
+     * @param protocol          protocol string
+     * @param eventType         {@link #EVENT_TYPE_CHANGE}, {@link #EVENT_TYPE_DELETE}, or {@link #EVENT_TYPE_ERROR}
+     * @param functionName      the listener resource function name (e.g. {@code "onFileChange"})
+     * @param entryFunctionName the entry-point Ballerina function name, or {@link #UNKNOWN}
      */
-    public static void reportFileEvent(String url, String protocol, String eventType) {
+    public static void reportFileEvent(String url, String protocol, String eventType,
+                                       String functionName, String entryFunctionName) {
         if (!ObserveUtils.isMetricsEnabled()) {
             return;
         }
         FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_LISTENER, url, protocol);
         observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
+        if (functionName != null) {
+            observerContext.addTag(FtpObserverContext.TAG_FUNCTION_NAME, functionName);
+        }
+        if (entryFunctionName != null) {
+            observerContext.addTag(FtpObserverContext.TAG_ENTRY_FUNCTION_NAME, entryFunctionName);
+        }
+        observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, INSTANCE_URL);
         incrementCounter(observerContext, METRIC_FILE_EVENTS[0], METRIC_FILE_EVENTS[1]);
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
@@ -31,22 +31,13 @@ import java.net.InetAddress;
  *
  * <p>Metrics published:
  * <ul>
- *   <li>{@code ftp_active_connections} (gauge) — active FTP/FTPS/SFTP connections</li>
- *   <li>{@code ftp_file_operations} (counter) — client file operations</li>
- *   <li>{@code ftp_file_events} (counter) — listener file events</li>
- *   <li>{@code ftp_errors} (counter) — errors by type</li>
+ *   <li>{@code ftp_active_connections} (gauge) — number of active FTP/FTPS/SFTP connections</li>
  * </ul>
  */
 public class FtpMetricsUtil {
     private static final String CONNECTOR_NAME = "ftp";
     private static final String[] METRIC_ACTIVE_CONNECTIONS = {
             "active_connections", "Number of active FTP/FTPS/SFTP connections"};
-    private static final String[] METRIC_FILE_OPERATIONS = {
-            "file_operations", "Number of file operations performed"};
-    private static final String[] METRIC_FILE_EVENTS = {
-            "file_events", "Number of file events dispatched by the listener"};
-    private static final String[] METRIC_ERRORS = {
-            "errors", "Number of errors"};
 
     /** Sentinel used when a URL or protocol value is unavailable. */
     public static final String UNKNOWN = "unknown";
@@ -83,6 +74,12 @@ public class FtpMetricsUtil {
 
     /** Operation-type tag value: {@code ftp:Client.rmdir()}. */
     public static final String OPERATION_TYPE_RMDIR = "rmdir";
+
+    /** Action-type tag value for FTP client operations (get, put, delete, etc.). */
+    public static final String ACTION_TYPE_OPERATION = "operation";
+
+    /** Action-type tag value for FTP listener event dispatches (change, delete, error). */
+    public static final String ACTION_TYPE_EVENT = "event";
 
     /** Error-type tag value: connection-level failure. */
     public static final String ERROR_TYPE_CONNECTION = "connection";
@@ -158,82 +155,7 @@ public class FtpMetricsUtil {
     }
 
     /**
-     * Increments the file-operations counter for any client operation.
-     * File paths are intentionally excluded to avoid unbounded metric cardinality;
-     * they are captured instead as tags on the trace span context.
-     *
-     * @param url               remote URL
-     * @param protocol          protocol string
-     * @param operationType     one of the {@code OPERATION_TYPE_*} constants
-     * @param functionName      the Ballerina client function name (e.g. {@code "getBytes"})
-     * @param entryFunctionName the entry-point Ballerina function name, or {@link #UNKNOWN}
-     */
-    public static void reportFileOperation(String url, String protocol, String operationType,
-                                           String functionName, String entryFunctionName) {
-        if (!ObserveUtils.isMetricsEnabled()) {
-            return;
-        }
-        FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_CLIENT, url, protocol);
-        observerContext.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
-        if (functionName != null) {
-            observerContext.addTag(FtpObserverContext.TAG_FUNCTION_NAME, functionName);
-        }
-        if (entryFunctionName != null) {
-            observerContext.addTag(FtpObserverContext.TAG_ENTRY_FUNCTION_NAME, entryFunctionName);
-        }
-        observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, INSTANCE_URL);
-        incrementCounter(observerContext, METRIC_FILE_OPERATIONS[0], METRIC_FILE_OPERATIONS[1]);
-    }
-
-    /**
-     * Increments the file-events counter when the listener dispatches a resource method.
-     * File paths are excluded from the counter to avoid unbounded cardinality;
-     * they are captured on the trace span context instead.
-     *
-     * @param url               remote URL
-     * @param protocol          protocol string
-     * @param eventType         {@link #EVENT_TYPE_CHANGE}, {@link #EVENT_TYPE_DELETE}, or {@link #EVENT_TYPE_ERROR}
-     * @param functionName      the listener resource function name (e.g. {@code "onFileChange"})
-     * @param entryFunctionName the entry-point Ballerina function name, or {@link #UNKNOWN}
-     */
-    public static void reportFileEvent(String url, String protocol, String eventType,
-                                       String functionName, String entryFunctionName) {
-        if (!ObserveUtils.isMetricsEnabled()) {
-            return;
-        }
-        FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_LISTENER, url, protocol);
-        observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
-        if (functionName != null) {
-            observerContext.addTag(FtpObserverContext.TAG_FUNCTION_NAME, functionName);
-        }
-        if (entryFunctionName != null) {
-            observerContext.addTag(FtpObserverContext.TAG_ENTRY_FUNCTION_NAME, entryFunctionName);
-        }
-        observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, INSTANCE_URL);
-        incrementCounter(observerContext, METRIC_FILE_EVENTS[0], METRIC_FILE_EVENTS[1]);
-    }
-
-    /**
-     * Increments the errors counter.
-     *
-     * @param url       host:port
-     * @param protocol  protocol string
-     * @param context   client or listener
-     * @param errorType one of the {@code ERROR_TYPE_*} constants
-     */
-    public static void reportError(String url, String protocol, String context, String errorType) {
-        if (!ObserveUtils.isMetricsEnabled()) {
-            return;
-        }
-        FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
-        observerContext.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
-        incrementCounter(observerContext, METRIC_ERRORS[0], METRIC_ERRORS[1]);
-    }
-
-    /**
-     * Maps a raw {@link Throwable} (e.g. from {@code RemoteFileSystemListener.onError})
-     * directly to an observability error-type constant, eliminating the need for callers
-     * to pass through {@code FtpUtil.getErrorTypeForException} first.
+     * Maps a raw {@link Throwable} to an observability error-type constant.
      *
      * @param throwable the exception to classify
      * @return the matching {@code ERROR_TYPE_*} string
@@ -262,16 +184,9 @@ public class FtpMetricsUtil {
             case "RetryError" -> ERROR_TYPE_RETRY_EXHAUSTED;
             case "CircuitBreakerOpenError" -> ERROR_TYPE_CIRCUIT_BREAKER_OPEN;
             case "InvalidConfigError" -> ERROR_TYPE_INVALID_CONFIG;
+            case "CloseError" -> ERROR_TYPE_CLOSE;
             default -> UNKNOWN;
         };
-    }
-
-    private static void incrementCounter(FtpObserverContext observerContext, String name, String desc) {
-        if (metricRegistry == null) {
-            return;
-        }
-        metricRegistry.counter(new MetricId(CONNECTOR_NAME + "_" + name, desc, observerContext.getAllTags()))
-                .increment();
     }
 
     private static void incrementGauge(FtpObserverContext observerContext, String name, String desc) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
@@ -26,17 +26,16 @@ import io.ballerina.runtime.observability.ObserverContext;
  */
 public class FtpObserverContext extends ObserverContext {
 
-    private static final String TAG_CONTEXT = "context";
-    private static final String TAG_REMOTE_URL = "remote_url";
-    private static final String TAG_PROTOCOL = "protocol";
+    static final String TAG_CONTEXT = "context";
+    static final String TAG_REMOTE_URL = "remote_url";
+    static final String TAG_PROTOCOL = "protocol";
 
     static final String TAG_FILE_PATH = "file.path";
     static final String TAG_DESTINATION_PATH = "destination.path";
     static final String TAG_EVENT_TYPE = "event.type";
     static final String TAG_OPERATION_TYPE = "operation.type";
     static final String TAG_ERROR_TYPE = "error_type";
-    static final String TAG_FUNCTION_NAME = "function.name";
-    static final String TAG_ENTRY_FUNCTION_NAME = "entry.function.name";
+    static final String TAG_ACTION_TYPE = "action.type";
     static final String TAG_INSTANCE_URL = "instance.url";
 
     FtpObserverContext(String context) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
@@ -22,21 +22,21 @@ import io.ballerina.runtime.observability.ObserverContext;
 
 /**
  * Extension of ObserverContext for the FTP connector.
- * Automatically attaches {@code context}, {@code remote_url}, and {@code protocol} tags.
+ * Automatically attaches {@code context}, {@code remote.url}, and {@code protocol} tags.
  */
 public class FtpObserverContext extends ObserverContext {
 
     static final String TAG_CONTEXT = "context";
-    static final String TAG_REMOTE_URL = "remote_url";
+    static final String TAG_REMOTE_URL = "remote.url";
     static final String TAG_PROTOCOL = "protocol";
 
     static final String TAG_FILE_PATH = "file.path";
     static final String TAG_DESTINATION_PATH = "destination.path";
     static final String TAG_EVENT_TYPE = "event.type";
     static final String TAG_OPERATION_TYPE = "operation.type";
-    static final String TAG_ERROR_TYPE = "error_type";
+    static final String TAG_ERROR_TYPE = "error.type";
     static final String TAG_ACTION_TYPE = "action.type";
-    static final String TAG_INSTANCE_URL = "instance.url";
+    static final String TAG_INSTANCE_URL = "host";
 
     FtpObserverContext(String context) {
         addTag(TAG_CONTEXT, context);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
@@ -35,6 +35,9 @@ public class FtpObserverContext extends ObserverContext {
     static final String TAG_EVENT_TYPE = "event.type";
     static final String TAG_OPERATION_TYPE = "operation.type";
     static final String TAG_ERROR_TYPE = "error_type";
+    static final String TAG_FUNCTION_NAME = "function.name";
+    static final String TAG_ENTRY_FUNCTION_NAME = "entry.function.name";
+    static final String TAG_INSTANCE_URL = "instance.url";
 
     FtpObserverContext(String context) {
         addTag(TAG_CONTEXT, context);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.ftp.observability;
+
+import io.ballerina.runtime.observability.ObserverContext;
+
+/**
+ * Extension of ObserverContext for the FTP connector.
+ * Automatically attaches {@code context}, {@code remote_url}, and {@code protocol} tags.
+ */
+public class FtpObserverContext extends ObserverContext {
+
+    private static final String TAG_CONTEXT = "context";
+    private static final String TAG_REMOTE_URL = "remote_url";
+    private static final String TAG_PROTOCOL = "protocol";
+
+    static final String TAG_FILE_PATH = "file.path";
+    static final String TAG_DESTINATION_PATH = "destination.path";
+    static final String TAG_EVENT_TYPE = "event.type";
+    static final String TAG_OPERATION_TYPE = "operation.type";
+    static final String TAG_ERROR_TYPE = "error_type";
+
+    FtpObserverContext(String context) {
+        addTag(TAG_CONTEXT, context);
+    }
+
+    public FtpObserverContext(String context, String remoteUrl, String protocol) {
+        this(context);
+        addTag(TAG_REMOTE_URL, remoteUrl != null ? remoteUrl : FtpMetricsUtil.UNKNOWN);
+        addTag(TAG_PROTOCOL, protocol != null ? protocol : FtpMetricsUtil.UNKNOWN);
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -41,6 +41,9 @@ import java.util.Map;
  */
 public class FtpTracingUtil {
 
+    private FtpTracingUtil() {
+    }
+
     /**
      * Creates strand properties containing an {@link FtpObserverContext} for the given
      * connection coordinates, event type, and file path.
@@ -138,8 +141,5 @@ public class FtpTracingUtil {
             ctx.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
         }
         return ctx;
-    }
-
-    private FtpTracingUtil() {
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -57,7 +57,9 @@ public class FtpTracingUtil {
      * @param url       host:port of the remote server
      * @param protocol  "ftp", "ftps", or "sftp"
      * @param eventType event type tag value (e.g. {@link FtpMetricsUtil#EVENT_TYPE_CHANGE})
-     * @param filePath  path of the file involved
+     * @param filePath  retained for API compatibility; not added to the context — {@code file.path}
+     *                  is excluded from metric labels (unbounded cardinality) and cannot be added
+     *                  span-only here because the span does not exist until the strand starts
      * @return properties map, or {@code null} if observability is disabled
      */
     public static Map<String, Object> createStrandProperties(String context, String url, String protocol,
@@ -72,7 +74,6 @@ public class FtpTracingUtil {
             observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
         }
         observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
-        observerContext.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
         Map<String, Object> properties = new HashMap<>();
         properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
         return properties;

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -18,46 +18,48 @@
 
 package io.ballerina.stdlib.ftp.observability;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.observability.ObservabilityConstants;
 import io.ballerina.runtime.observability.ObserveUtils;
+import io.ballerina.runtime.observability.ObserverContext;
 
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Utility class for injecting FTP trace spans into Ballerina strands.
+ * Utility class for injecting FTP observability context into Ballerina strands and spans.
  *
- * <p>Usage — call {@code createStrandProperties} to get a properties map that can be
- * passed as the second argument of {@code StrandMetadata}. The runtime will pick up
- * the embedded {@link FtpObserverContext} and create a child span automatically.
- *
- * <pre>{@code
- * Map<String, Object> props = FtpTracingUtil.createStrandProperties(
- *         FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
- *         FtpMetricsUtil.EVENT_TYPE_CHANGE, filePath);
- * StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, props);
- * runtime.callMethod(service, methodName, strandMetadata, args);
- * }</pre>
+ * <p>Two usage patterns:
+ * <ul>
+ *   <li><b>Listener dispatch</b> — call {@link #createStrandProperties} to build a properties map
+ *       that is embedded in {@code StrandMetadata} when dispatching a service method via
+ *       {@code callMethod}. The runtime picks up the embedded {@link FtpObserverContext} and uses
+ *       it as the span context for the entire service-method execution.</li>
+ *   <li><b>Caller / client operations</b> — call {@link #sendMetricsData} from
+ *       inside a native external method. Ballerina has already created an auto-instrumented span
+ *       for the remote-method call; this helper enriches that span with the FTP-specific tags
+ *       ({@code action_type}, {@code context}, {@code remote_url}, etc.) so that the resulting
+ *       {@code requests_total_value} metric is correctly labelled.</li>
+ * </ul>
  */
 public class FtpTracingUtil {
+    private static final String TAG_SRC_CLIENT_REMOTE = "src.client.remote";
 
     private FtpTracingUtil() {
     }
 
     /**
-     * Creates strand properties containing an {@link FtpObserverContext} for the given
-     * connection coordinates, event type, and file path.
+     * Creates strand properties containing an {@link FtpObserverContext} for a listener event
+     * dispatch. Pass the returned map to {@code new StrandMetadata(isConcurrentSafe, props)} when
+     * invoking a service method via {@code callMethod}.
      *
-     * <p>Returns {@code null} when tracing is disabled so callers can pass it directly
-     * to {@code new StrandMetadata(isConcurrentSafe, props)} without branching.
-     *
-     * @param context   {@link FtpMetricsUtil#CONTEXT_CLIENT} or {@link FtpMetricsUtil#CONTEXT_LISTENER}
+     * @param context   {@link FtpMetricsUtil#CONTEXT_LISTENER}
      * @param url       host:port of the remote server
      * @param protocol  "ftp", "ftps", or "sftp"
      * @param eventType event type tag value (e.g. {@link FtpMetricsUtil#EVENT_TYPE_CHANGE}),
      *                  or {@code null} to omit
      * @param filePath  path of the file involved, or {@code null} to omit
-     * @return properties map to pass to {@code StrandMetadata}, or {@code null}
+     * @return properties map, or {@code null} if tracing is disabled
      */
     public static Map<String, Object> createStrandProperties(String context, String url, String protocol,
                                                               String eventType, String filePath) {
@@ -65,6 +67,10 @@ public class FtpTracingUtil {
             return null;
         }
         FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+        observerContext.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_EVENT);
+        if (FtpMetricsUtil.INSTANCE_URL != null) {
+            observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, FtpMetricsUtil.INSTANCE_URL);
+        }
         if (eventType != null) {
             observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
         }
@@ -77,14 +83,8 @@ public class FtpTracingUtil {
     }
 
     /**
-     * Creates strand properties for a listener dispatch that has no specific file path
+     * Overload without {@code filePath} for dispatches that have no single source file
      * (e.g. batch deletions routed to {@code onFileDeleted}).
-     *
-     * @param context  context tag
-     * @param url      host:port
-     * @param protocol protocol string
-     * @param eventType event type tag value, or {@code null}
-     * @return properties map or {@code null} if tracing is disabled
      */
     public static Map<String, Object> createStrandProperties(String context, String url, String protocol,
                                                               String eventType) {
@@ -92,54 +92,121 @@ public class FtpTracingUtil {
     }
 
     /**
-     * Builds a tagged {@link FtpObserverContext} for a client-side FTP operation.
-     * Returns {@code null} when tracing is disabled.
+     * Creates strand properties for a listener error dispatch, adding {@code event.type=error}
+     * and an {@code error_type} tag to the embedded observer context.
      *
-     * <p>The context carries the {@code remote_url}, {@code protocol}, {@code context},
-     * {@code operation.type}, and {@code file.path} tags so they are available for
-     * enriching whichever span mechanism the runtime supports.
-     * Span lifecycle (start/finish) is handled by Ballerina's auto-instrumentation for
-     * {@code client->method()} calls; this context supplements those spans with
-     * FTP-specific tags when a native-code span API becomes available.
-     *
-     * @param url           remote URL (e.g. {@code sftp://host:22})
-     * @param protocol      "ftp", "ftps", or "sftp"
-     * @param operationType one of the {@code FtpMetricsUtil.OPERATION_TYPE_*} constants
-     * @param filePath      source/target file path, or {@code null} to omit
-     * @return tagged observer context, or {@code null} if tracing is disabled
+     * @param context   context tag
+     * @param url       host:port
+     * @param protocol  protocol string
+     * @param filePath  path of the file involved, or {@code null}
+     * @param errorType one of the {@code FtpMetricsUtil.ERROR_TYPE_*} constants, or {@code null}
+     * @return properties map, or {@code null} if tracing is disabled
      */
-    public static FtpObserverContext createClientSpanContext(String url, String protocol,
-                                                              String operationType, String filePath) {
-        return createClientSpanContext(url, protocol, operationType, filePath, null);
+    public static Map<String, Object> createErrorStrandProperties(String context, String url, String protocol,
+                                                                   String filePath, String errorType) {
+        Map<String, Object> props = createStrandProperties(context, url, protocol,
+                FtpMetricsUtil.EVENT_TYPE_ERROR, filePath);
+        if (props != null && errorType != null) {
+            FtpObserverContext ctx = (FtpObserverContext) props.get(ObservabilityConstants.KEY_OBSERVER_CONTEXT);
+            if (ctx != null) {
+                ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
+            }
+        }
+        return props;
     }
 
     /**
-     * Builds a tagged {@link FtpObserverContext} for a two-path client operation
-     * (rename, move, copy), including a {@code destination.path} tag.
+     * Enriches the auto-instrumented span for the currently executing native external method with
+     * FTP client-operation tags.
      *
-     * @param url             remote URL
-     * @param protocol        protocol string
-     * @param operationType   operation type constant
-     * @param filePath        source path, or {@code null}
-     * @param destinationPath destination path, or {@code null}
-     * @return tagged observer context, or {@code null} if tracing is disabled
+     * <p>Ballerina creates an observer context (span) for every remote-method call before
+     * invoking the external Java implementation. Calling this method from inside the native
+     * implementation adds the FTP-specific tags to that span, so that the corresponding
+     * {@code requests_total_value} metric carries {@code action_type="operation"},
+     * {@code context="client"}, {@code remote_url}, {@code protocol}, {@code operation.type},
+     * {@code file.path}, and {@code instance.url}.
+     *
+     * @param env           the current Ballerina environment
+     * @param url           remote URL, or {@code null} to omit
+     * @param protocol      protocol string, or {@code null} to omit
+     * @param operationType one of the {@code FtpMetricsUtil.OPERATION_TYPE_*} constants
+     * @param filePath      source/target file path, or {@code null} to omit
      */
-    public static FtpObserverContext createClientSpanContext(String url, String protocol,
-                                                              String operationType, String filePath,
-                                                              String destinationPath) {
-        if (!ObserveUtils.isTracingEnabled()) {
-            return null;
+    public static void sendMetricsData(Environment env, String url, String protocol,
+                                                        String operationType, String filePath) {
+        sendMetricsData(env, url, protocol, operationType, filePath, null);
+    }
+
+    /**
+     * Variant for two-path operations ({@code rename}, {@code move}, {@code copy}), adding
+     * a {@code destination.path} tag in addition to the standard operation tags.
+     *
+     * @param env             the current Ballerina environment
+     * @param url             remote URL, or {@code null} to omit
+     * @param protocol        protocol string, or {@code null} to omit
+     * @param operationType   operation type constant
+     * @param filePath        source path, or {@code null} to omit
+     * @param destinationPath destination path, or {@code null} to omit
+     */
+    public static void sendMetricsData(Environment env, String url, String protocol,
+                                                        String operationType, String filePath,
+                                                        String destinationPath) {
+        ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
+        if (ctx == null) {
+            return;
         }
-        FtpObserverContext ctx = new FtpObserverContext(FtpMetricsUtil.CONTEXT_CLIENT, url, protocol);
+        ObserverContext target = ctx;
+        if (ctx.getTag(TAG_SRC_CLIENT_REMOTE) == null) {
+            ObserverContext parent = ctx.getParent();
+            if (parent != null) {
+                target = parent;
+            }
+        }
+        target.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_OPERATION);
+        target.addTag(FtpObserverContext.TAG_CONTEXT, FtpMetricsUtil.CONTEXT_CLIENT);
+        if (url != null) {
+            target.addTag(FtpObserverContext.TAG_REMOTE_URL, url);
+        }
+        if (protocol != null) {
+            target.addTag(FtpObserverContext.TAG_PROTOCOL, protocol);
+        }
         if (operationType != null) {
-            ctx.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
+            target.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
         }
         if (filePath != null) {
-            ctx.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
+            target.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
         }
         if (destinationPath != null) {
-            ctx.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
+            target.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
         }
-        return ctx;
+        if (FtpMetricsUtil.INSTANCE_URL != null) {
+            target.addTag(FtpObserverContext.TAG_INSTANCE_URL, FtpMetricsUtil.INSTANCE_URL);
+        }
+    }
+
+    /**
+     * Adds an {@code error_type} tag to the auto-instrumented span for the currently executing
+     * native external method. Call this after an operation returns a {@link BError} to record
+     * the error classification on the span.
+     *
+     * @param env       the current Ballerina environment; if {@code null} this is a no-op
+     * @param errorType one of the {@code FtpMetricsUtil.ERROR_TYPE_*} constants
+     */
+    public static void sendErrorMetricsOnCurrentFrame(Environment env, String errorType) {
+        if (env == null || errorType == null) {
+            return;
+        }
+        ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
+        if (ctx == null) {
+            return;
+        }
+        ObserverContext target = ctx;
+        if (ctx.getTag(TAG_SRC_CLIENT_REMOTE) == null) {
+            ObserverContext parent = ctx.getParent();
+            if (parent != null) {
+                target = parent;
+            }
+        }
+        target.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -68,8 +68,9 @@ public class FtpTracingUtil {
         }
         FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
         observerContext.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_EVENT);
-        if (FtpMetricsUtil.INSTANCE_URL != null) {
-            observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, FtpMetricsUtil.INSTANCE_URL);
+        String instanceUrl = FtpMetricsUtil.getInstanceUrl();
+        if (instanceUrl != null) {
+            observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
         }
         if (eventType != null) {
             observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
@@ -179,8 +180,9 @@ public class FtpTracingUtil {
         if (destinationPath != null) {
             target.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
         }
-        if (FtpMetricsUtil.INSTANCE_URL != null) {
-            target.addTag(FtpObserverContext.TAG_INSTANCE_URL, FtpMetricsUtil.INSTANCE_URL);
+        String instanceUrl = FtpMetricsUtil.getInstanceUrl();
+        if (instanceUrl != null) {
+            target.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -57,7 +57,7 @@ public class FtpTracingUtil {
      * @param url       host:port of the remote server
      * @param protocol  "ftp", "ftps", or "sftp"
      * @param eventType event type tag value (e.g. {@link FtpMetricsUtil#EVENT_TYPE_CHANGE})
-     * @param filePath  path of the file involved, or {@code null} to omit
+     * @param filePath  path of the file involved
      * @return properties map, or {@code null} if tracing is disabled
      */
     public static Map<String, Object> createStrandProperties(String context, String url, String protocol,
@@ -71,12 +71,8 @@ public class FtpTracingUtil {
         if (instanceUrl != null) {
             observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
         }
-        if (eventType != null) {
-            observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
-        }
-        if (filePath != null) {
-            observerContext.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
-        }
+        observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
+        observerContext.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
         Map<String, Object> properties = new HashMap<>();
         properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
         return properties;

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -38,7 +38,7 @@ import java.util.Map;
  *   <li><b>Caller / client operations</b> — call {@link #sendMetricsData} from
  *       inside a native external method. Ballerina has already created an auto-instrumented span
  *       for the remote-method call; this helper enriches that span with the FTP-specific tags
- *       ({@code action_type}, {@code context}, {@code remote_url}, etc.) so that the resulting
+ *       ({@code action_type}, {@code context}, {@code remote.url}, etc.) so that the resulting
  *       {@code requests_total_value} metric is correctly labelled.</li>
  * </ul>
  */
@@ -94,7 +94,7 @@ public class FtpTracingUtil {
 
     /**
      * Creates strand properties for a listener error dispatch, adding {@code event.type=error}
-     * and an {@code error_type} tag to the embedded observer context.
+     * and an {@code error.type} tag to the embedded observer context.
      *
      * @param context   context tag
      * @param url       host:port
@@ -124,8 +124,8 @@ public class FtpTracingUtil {
      * invoking the external Java implementation. Calling this method from inside the native
      * implementation adds the FTP-specific tags to that span, so that the corresponding
      * {@code requests_total_value} metric carries {@code action_type="operation"},
-     * {@code context="client"}, {@code remote_url}, {@code protocol}, {@code operation.type},
-     * {@code file.path}, and {@code instance.url}.
+     * {@code context="client"}, {@code remote.url}, {@code protocol}, {@code operation.type},
+     * {@code file.path}, and {@code host}.
      *
      * @param env           the current Ballerina environment
      * @param url           remote URL, or {@code null} to omit
@@ -187,7 +187,7 @@ public class FtpTracingUtil {
     }
 
     /**
-     * Adds an {@code error_type} tag to the auto-instrumented span for the currently executing
+     * Adds an {@code error.type} tag to the auto-instrumented span for the currently executing
      * native external method. Call this after an operation returns a {@link BError} to record
      * the error classification on the span.
      *

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -56,8 +56,7 @@ public class FtpTracingUtil {
      * @param context   {@link FtpMetricsUtil#CONTEXT_LISTENER}
      * @param url       host:port of the remote server
      * @param protocol  "ftp", "ftps", or "sftp"
-     * @param eventType event type tag value (e.g. {@link FtpMetricsUtil#EVENT_TYPE_CHANGE}),
-     *                  or {@code null} to omit
+     * @param eventType event type tag value (e.g. {@link FtpMetricsUtil#EVENT_TYPE_CHANGE})
      * @param filePath  path of the file involved, or {@code null} to omit
      * @return properties map, or {@code null} if tracing is disabled
      */
@@ -100,7 +99,7 @@ public class FtpTracingUtil {
      * @param url       host:port
      * @param protocol  protocol string
      * @param filePath  path of the file involved, or {@code null}
-     * @param errorType one of the {@code FtpMetricsUtil.ERROR_TYPE_*} constants, or {@code null}
+     * @param errorType Ballerina error type name (e.g. {@code "ConnectionError"}), or {@code null}
      * @return properties map, or {@code null} if tracing is disabled
      */
     public static Map<String, Object> createErrorStrandProperties(String context, String url, String protocol,
@@ -192,7 +191,7 @@ public class FtpTracingUtil {
      * the error classification on the span.
      *
      * @param env       the current Ballerina environment; if {@code null} this is a no-op
-     * @param errorType one of the {@code FtpMetricsUtil.ERROR_TYPE_*} constants
+     * @param errorType Ballerina error type name (e.g. {@code "ConnectionError"})
      */
     public static void sendErrorMetricsOnCurrentFrame(Environment env, String errorType) {
         if (env == null || errorType == null) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.observability.ObservabilityConstants;
 import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.ObserverContext;
+import io.ballerina.runtime.observability.tracer.BSpan;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,15 +36,14 @@ import java.util.Map;
  *       that is embedded in {@code StrandMetadata} when dispatching a service method via
  *       {@code callMethod}. The runtime picks up the embedded {@link FtpObserverContext} and uses
  *       it as the span context for the entire service-method execution.</li>
- *   <li><b>Caller / client operations</b> — call {@link #sendMetricsData} from
- *       inside a native external method. Ballerina has already created an auto-instrumented span
- *       for the remote-method call; this helper enriches that span with the FTP-specific tags
- *       ({@code action_type}, {@code context}, {@code remote.url}, etc.) so that the resulting
+ *   <li><b>Client operations</b> — call {@link #sendMetricsData} from inside a native external
+ *       method. Ballerina has already created an auto-instrumented span for the remote-method call;
+ *       this helper enriches that span with the FTP-specific tags ({@code action.type},
+ *       {@code context}, {@code remote.url}, etc.) so that the resulting
  *       {@code requests_total_value} metric is correctly labelled.</li>
  * </ul>
  */
 public class FtpTracingUtil {
-    private static final String TAG_SRC_CLIENT_REMOTE = "src.client.remote";
 
     private FtpTracingUtil() {
     }
@@ -58,11 +58,11 @@ public class FtpTracingUtil {
      * @param protocol  "ftp", "ftps", or "sftp"
      * @param eventType event type tag value (e.g. {@link FtpMetricsUtil#EVENT_TYPE_CHANGE})
      * @param filePath  path of the file involved
-     * @return properties map, or {@code null} if tracing is disabled
+     * @return properties map, or {@code null} if observability is disabled
      */
     public static Map<String, Object> createStrandProperties(String context, String url, String protocol,
                                                               String eventType, String filePath) {
-        if (!ObserveUtils.isTracingEnabled()) {
+        if (!ObserveUtils.isObservabilityEnabled()) {
             return null;
         }
         FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
@@ -95,115 +95,88 @@ public class FtpTracingUtil {
      * @param url       host:port
      * @param protocol  protocol string
      * @param filePath  path of the file involved, or {@code null}
-     * @param errorType Ballerina error type name (e.g. {@code "ConnectionError"}), or {@code null}
-     * @return properties map, or {@code null} if tracing is disabled
+     * @param errorType Ballerina error type name (e.g. {@code "ConnectionError"})
+     * @return properties map, or {@code null} if observability is disabled
      */
     public static Map<String, Object> createErrorStrandProperties(String context, String url, String protocol,
                                                                    String filePath, String errorType) {
         Map<String, Object> props = createStrandProperties(context, url, protocol,
                 FtpMetricsUtil.EVENT_TYPE_ERROR, filePath);
-        if (props != null && errorType != null) {
+        if (props != null) {
             FtpObserverContext ctx = (FtpObserverContext) props.get(ObservabilityConstants.KEY_OBSERVER_CONTEXT);
-            if (ctx != null) {
-                ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
-            }
+            ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
         }
         return props;
     }
 
     /**
      * Enriches the auto-instrumented span for the currently executing native external method with
-     * FTP client-operation tags.
-     *
-     * <p>Ballerina creates an observer context (span) for every remote-method call before
-     * invoking the external Java implementation. Calling this method from inside the native
-     * implementation adds the FTP-specific tags to that span, so that the corresponding
-     * {@code requests_total_value} metric carries {@code action_type="operation"},
-     * {@code context="client"}, {@code remote.url}, {@code protocol}, {@code operation.type},
-     * {@code file.path}, and {@code host}.
+     * FTP client-operation tags. Metric tags ({@code action.type}, {@code context},
+     * {@code remote.url}, {@code protocol}, {@code operation.type}) are added to the
+     * {@link ObserverContext}; {@code file.path} and {@code destination.path} are span-only and
+     * excluded from metrics to prevent unbounded label cardinality.
      *
      * @param env           the current Ballerina environment
-     * @param url           remote URL, or {@code null} to omit
-     * @param protocol      protocol string, or {@code null} to omit
+     * @param url           remote URL
+     * @param protocol      protocol string
      * @param operationType one of the {@code FtpMetricsUtil.OPERATION_TYPE_*} constants
-     * @param filePath      source/target file path, or {@code null} to omit
+     * @param filePath      source/target file path
      */
     public static void sendMetricsData(Environment env, String url, String protocol,
-                                                        String operationType, String filePath) {
+                                       String operationType, String filePath) {
         sendMetricsData(env, url, protocol, operationType, filePath, null);
     }
 
     /**
      * Variant for two-path operations ({@code rename}, {@code move}, {@code copy}), adding
-     * a {@code destination.path} tag in addition to the standard operation tags.
+     * a span-only {@code destination.path} tag.
      *
      * @param env             the current Ballerina environment
-     * @param url             remote URL, or {@code null} to omit
-     * @param protocol        protocol string, or {@code null} to omit
+     * @param url             remote URL
+     * @param protocol        protocol string
      * @param operationType   operation type constant
-     * @param filePath        source path, or {@code null} to omit
-     * @param destinationPath destination path, or {@code null} to omit
+     * @param filePath        source path
+     * @param destinationPath destination path, or {@code null} for single-path operations
      */
     public static void sendMetricsData(Environment env, String url, String protocol,
-                                                        String operationType, String filePath,
-                                                        String destinationPath) {
+                                       String operationType, String filePath,
+                                       String destinationPath) {
         ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
         if (ctx == null) {
             return;
         }
-        ObserverContext target = ctx;
-        if (ctx.getTag(TAG_SRC_CLIENT_REMOTE) == null) {
-            ObserverContext parent = ctx.getParent();
-            if (parent != null) {
-                target = parent;
-            }
-        }
-        target.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_OPERATION);
-        target.addTag(FtpObserverContext.TAG_CONTEXT, FtpMetricsUtil.CONTEXT_CLIENT);
-        if (url != null) {
-            target.addTag(FtpObserverContext.TAG_REMOTE_URL, url);
-        }
-        if (protocol != null) {
-            target.addTag(FtpObserverContext.TAG_PROTOCOL, protocol);
-        }
-        if (operationType != null) {
-            target.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
-        }
-        if (filePath != null) {
-            target.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
-        }
-        if (destinationPath != null) {
-            target.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
-        }
+        ctx.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_OPERATION);
+        ctx.addTag(FtpObserverContext.TAG_CONTEXT, FtpMetricsUtil.CONTEXT_CLIENT);
+        ctx.addTag(FtpObserverContext.TAG_REMOTE_URL, url);
+        ctx.addTag(FtpObserverContext.TAG_PROTOCOL, protocol);
+        ctx.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
         String instanceUrl = FtpMetricsUtil.getInstanceUrl();
         if (instanceUrl != null) {
-            target.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+            ctx.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+        }
+        BSpan span = ctx.getSpan();
+        if (span != null) {
+            span.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
+            if (destinationPath != null) {
+                span.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
+            }
         }
     }
 
     /**
-     * Adds an {@code error.type} tag to the auto-instrumented span for the currently executing
-     * native external method. Call this after an operation returns a {@link BError} to record
-     * the error classification on the span.
+     * Adds {@code error=true} and {@code error.type} tags to the auto-instrumented span for the
+     * currently executing native external method. Call this after an operation returns a
+     * {@link io.ballerina.runtime.api.values.BError} to record the error on the span.
      *
-     * @param env       the current Ballerina environment; if {@code null} this is a no-op
+     * @param env       the current Ballerina environment
      * @param errorType Ballerina error type name (e.g. {@code "ConnectionError"})
      */
     public static void sendErrorMetricsOnCurrentFrame(Environment env, String errorType) {
-        if (env == null || errorType == null) {
-            return;
-        }
         ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
         if (ctx == null) {
             return;
         }
-        ObserverContext target = ctx;
-        if (ctx.getTag(TAG_SRC_CLIENT_REMOTE) == null) {
-            ObserverContext parent = ctx.getParent();
-            if (parent != null) {
-                target = parent;
-            }
-        }
-        target.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
+        ctx.addTag(ObservabilityConstants.TAG_KEY_ERROR, ObservabilityConstants.TAG_TRUE_VALUE);
+        ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com)
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.ftp.observability;
+
+import io.ballerina.runtime.observability.ObservabilityConstants;
+import io.ballerina.runtime.observability.ObserveUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utility class for injecting FTP trace spans into Ballerina strands.
+ *
+ * <p>Usage — call {@code createStrandProperties} to get a properties map that can be
+ * passed as the second argument of {@code StrandMetadata}. The runtime will pick up
+ * the embedded {@link FtpObserverContext} and create a child span automatically.
+ *
+ * <pre>{@code
+ * Map<String, Object> props = FtpTracingUtil.createStrandProperties(
+ *         FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
+ *         FtpMetricsUtil.EVENT_TYPE_CHANGE, filePath);
+ * StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, props);
+ * runtime.callMethod(service, methodName, strandMetadata, args);
+ * }</pre>
+ */
+public class FtpTracingUtil {
+
+    /**
+     * Creates strand properties containing an {@link FtpObserverContext} for the given
+     * connection coordinates, event type, and file path.
+     *
+     * <p>Returns {@code null} when tracing is disabled so callers can pass it directly
+     * to {@code new StrandMetadata(isConcurrentSafe, props)} without branching.
+     *
+     * @param context   {@link FtpMetricsUtil#CONTEXT_CLIENT} or {@link FtpMetricsUtil#CONTEXT_LISTENER}
+     * @param url       host:port of the remote server
+     * @param protocol  "ftp", "ftps", or "sftp"
+     * @param eventType event type tag value (e.g. {@link FtpMetricsUtil#EVENT_TYPE_CHANGE}),
+     *                  or {@code null} to omit
+     * @param filePath  path of the file involved, or {@code null} to omit
+     * @return properties map to pass to {@code StrandMetadata}, or {@code null}
+     */
+    public static Map<String, Object> createStrandProperties(String context, String url, String protocol,
+                                                              String eventType, String filePath) {
+        if (!ObserveUtils.isTracingEnabled()) {
+            return null;
+        }
+        FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+        if (eventType != null) {
+            observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
+        }
+        if (filePath != null) {
+            observerContext.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
+        }
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
+        return properties;
+    }
+
+    /**
+     * Creates strand properties for a listener dispatch that has no specific file path
+     * (e.g. batch deletions routed to {@code onFileDeleted}).
+     *
+     * @param context  context tag
+     * @param url      host:port
+     * @param protocol protocol string
+     * @param eventType event type tag value, or {@code null}
+     * @return properties map or {@code null} if tracing is disabled
+     */
+    public static Map<String, Object> createStrandProperties(String context, String url, String protocol,
+                                                              String eventType) {
+        return createStrandProperties(context, url, protocol, eventType, null);
+    }
+
+    /**
+     * Builds a tagged {@link FtpObserverContext} for a client-side FTP operation.
+     * Returns {@code null} when tracing is disabled.
+     *
+     * <p>The context carries the {@code remote_url}, {@code protocol}, {@code context},
+     * {@code operation.type}, and {@code file.path} tags so they are available for
+     * enriching whichever span mechanism the runtime supports.
+     * Span lifecycle (start/finish) is handled by Ballerina's auto-instrumentation for
+     * {@code client->method()} calls; this context supplements those spans with
+     * FTP-specific tags when a native-code span API becomes available.
+     *
+     * @param url           remote URL (e.g. {@code sftp://host:22})
+     * @param protocol      "ftp", "ftps", or "sftp"
+     * @param operationType one of the {@code FtpMetricsUtil.OPERATION_TYPE_*} constants
+     * @param filePath      source/target file path, or {@code null} to omit
+     * @return tagged observer context, or {@code null} if tracing is disabled
+     */
+    public static FtpObserverContext createClientSpanContext(String url, String protocol,
+                                                              String operationType, String filePath) {
+        return createClientSpanContext(url, protocol, operationType, filePath, null);
+    }
+
+    /**
+     * Builds a tagged {@link FtpObserverContext} for a two-path client operation
+     * (rename, move, copy), including a {@code destination.path} tag.
+     *
+     * @param url             remote URL
+     * @param protocol        protocol string
+     * @param operationType   operation type constant
+     * @param filePath        source path, or {@code null}
+     * @param destinationPath destination path, or {@code null}
+     * @return tagged observer context, or {@code null} if tracing is disabled
+     */
+    public static FtpObserverContext createClientSpanContext(String url, String protocol,
+                                                              String operationType, String filePath,
+                                                              String destinationPath) {
+        if (!ObserveUtils.isTracingEnabled()) {
+            return null;
+        }
+        FtpObserverContext ctx = new FtpObserverContext(FtpMetricsUtil.CONTEXT_CLIENT, url, protocol);
+        if (operationType != null) {
+            ctx.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
+        }
+        if (filePath != null) {
+            ctx.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
+        }
+        if (destinationPath != null) {
+            ctx.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
+        }
+        return ctx;
+    }
+
+    private FtpTracingUtil() {
+    }
+}

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -335,9 +335,7 @@ public class FtpContentCallbackHandler {
         Optional<PostProcessAction> onErrorAfterError = holder.getAfterErrorAction(onErrorMethod.getName());
         boolean hasOnErrorActions = onErrorAfterProcess.isPresent() || onErrorAfterError.isPresent();
 
-        String errorType = error.getType() != null
-                ? FtpMetricsUtil.toObservabilityErrorType(error.getType().getName())
-                : FtpMetricsUtil.UNKNOWN;
+        String errorType = error.getType() != null ? error.getType().getName() : FtpMetricsUtil.UNKNOWN;
         Map<String, Object> strandProperties = FtpTracingUtil.createErrorStrandProperties(
                 FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
                 fileInfo.getPath(), errorType);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -140,9 +140,6 @@ public class FtpContentCallbackHandler {
 
                 if (convertedContent instanceof BError bError) {
                     if (FtpUtil.ErrorType.ContentBindingError.errorType().equals(bError.getType().getName())) {
-                        FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
-                                FtpMetricsUtil.CONTEXT_LISTENER,
-                                FtpMetricsUtil.ERROR_TYPE_CONTENT_BINDING);
                         routeToOnError(service, holder, bError, callerObject, fileInfo, listenerPath,
                                 methodType.getName());
                     } else {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -59,6 +59,7 @@ import java.util.Optional;
 
 import static io.ballerina.runtime.api.types.TypeTags.OBJECT_TYPE_TAG;
 import static io.ballerina.runtime.api.types.TypeTags.RECORD_TYPE_TAG;
+import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_ERROR_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_CSV_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_JSON_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_REMOTE_FUNCTION;
@@ -346,6 +347,8 @@ public class FtpContentCallbackHandler {
                 : FtpMetricsUtil.UNKNOWN;
         FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
                 FtpMetricsUtil.CONTEXT_LISTENER, errorType);
+        FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol,
+                FtpMetricsUtil.EVENT_TYPE_ERROR, ON_ERROR_REMOTE_FUNCTION, ON_ERROR_REMOTE_FUNCTION);
 
         Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
                 FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -151,7 +151,7 @@ public class FtpContentCallbackHandler {
                 }
 
                 FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol,
-                        FtpMetricsUtil.EVENT_TYPE_CHANGE);
+                        FtpMetricsUtil.EVENT_TYPE_CHANGE, methodType.getName(), methodType.getName());
 
                 // Prepare method arguments
                 Object[] methodArguments = prepareContentMethodArguments(methodType, convertedContent,

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -59,7 +59,6 @@ import java.util.Optional;
 
 import static io.ballerina.runtime.api.types.TypeTags.OBJECT_TYPE_TAG;
 import static io.ballerina.runtime.api.types.TypeTags.RECORD_TYPE_TAG;
-import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_ERROR_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_CSV_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_JSON_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_REMOTE_FUNCTION;
@@ -147,9 +146,6 @@ public class FtpContentCallbackHandler {
                     }
                     continue;
                 }
-
-                FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol,
-                        FtpMetricsUtil.EVENT_TYPE_CHANGE, methodType.getName(), methodType.getName());
 
                 // Prepare method arguments
                 Object[] methodArguments = prepareContentMethodArguments(methodType, convertedContent,
@@ -342,14 +338,9 @@ public class FtpContentCallbackHandler {
         String errorType = error.getType() != null
                 ? FtpMetricsUtil.toObservabilityErrorType(error.getType().getName())
                 : FtpMetricsUtil.UNKNOWN;
-        FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
-                FtpMetricsUtil.CONTEXT_LISTENER, errorType);
-        FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol,
-                FtpMetricsUtil.EVENT_TYPE_ERROR, ON_ERROR_REMOTE_FUNCTION, ON_ERROR_REMOTE_FUNCTION);
-
-        Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
+        Map<String, Object> strandProperties = FtpTracingUtil.createErrorStrandProperties(
                 FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
-                FtpMetricsUtil.EVENT_TYPE_ERROR, fileInfo.getPath());
+                fileInfo.getPath(), errorType);
 
         Object[] methodArguments = prepareOnErrorMethodArguments(onErrorMethod, error, callerObject);
         invokeOnErrorMethodAsync(service, onErrorMethod.getName(), methodArguments, fileInfo, callerObject,
@@ -386,22 +377,14 @@ public class FtpContentCallbackHandler {
                 Object result = ballerinaRuntime.callMethod(service, methodName, strandMetadata, methodArguments);
                 if (result instanceof BError) {
                     ((BError) result).printStackTrace();
-                    FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
-                            FtpMetricsUtil.CONTEXT_LISTENER,
-                            FtpMetricsUtil.toObservabilityErrorType(((BError) result).getType().getName()));
                 } else {
                     isSuccess = true;
                 }
             } catch (BError error) {
                 error.printStackTrace();
-                FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
-                        FtpMetricsUtil.CONTEXT_LISTENER,
-                        FtpMetricsUtil.toObservabilityErrorType(error.getType().getName()));
             } catch (Exception exception) {
                 FtpUtil.createError("Error invoking onError method: " + methodName + " - " + exception.getMessage(),
                         exception, FtpConstants.FTP_ERROR).printStackTrace();
-                FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
-                        FtpMetricsUtil.CONTEXT_LISTENER, FtpMetricsUtil.ERROR_TYPE_CONNECTION);
             }
 
             if (isSuccess) {
@@ -430,9 +413,6 @@ public class FtpContentCallbackHandler {
 
                 if (result instanceof BError) {
                     ((BError) result).printStackTrace();
-                    FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
-                            FtpMetricsUtil.CONTEXT_LISTENER,
-                            FtpMetricsUtil.toObservabilityErrorType(((BError) result).getType().getName()));
                     // Method returned an error - execute afterError action
                     afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
                             listenerPath, ACTION_AFTER_ERROR));
@@ -441,17 +421,12 @@ public class FtpContentCallbackHandler {
                 }
             } catch (BError error) {
                 error.printStackTrace();
-                FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
-                        FtpMetricsUtil.CONTEXT_LISTENER,
-                        FtpMetricsUtil.toObservabilityErrorType(error.getType().getName()));
                 // Method threw an error - execute afterError action
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
                         listenerPath, ACTION_AFTER_ERROR));
             } catch (Exception exception) {
                 FtpUtil.createError("Error invoking content method: " + methodName + " - " + exception.getMessage(),
                         exception, FtpConstants.FTP_ERROR).printStackTrace();
-                FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
-                        FtpMetricsUtil.CONTEXT_LISTENER, FtpMetricsUtil.ERROR_TYPE_CONNECTION);
                 // Method threw an exception - execute afterError action
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
                         listenerPath, ACTION_AFTER_ERROR));

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -38,6 +38,8 @@ import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.ftp.ContentByteStreamIteratorUtils;
 import io.ballerina.stdlib.ftp.ContentCsvStreamIteratorUtils;
 import io.ballerina.stdlib.ftp.client.FtpRetryHelper;
+import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
+import io.ballerina.stdlib.ftp.observability.FtpTracingUtil;
 import io.ballerina.stdlib.ftp.transport.message.FileInfo;
 import io.ballerina.stdlib.ftp.transport.message.RemoteFileSystemEvent;
 import io.ballerina.stdlib.ftp.util.FtpConstants;
@@ -87,12 +89,14 @@ public class FtpContentCallbackHandler {
     private final double retryInterval;
     private final double retryBackoffFactor;
     private final double retryMaxWaitInterval;
+    private final String listenerUrl;
+    private final String listenerProtocol;
 
     public FtpContentCallbackHandler(Runtime ballerinaRuntime, FileSystemManager fileSystemManager,
                                      FileSystemOptions fileSystemOptions, boolean laxDataBinding,
                                      BMap<?, ?> csvFailSafe, boolean retryEnabled, long retryCount,
                                      double retryInterval, double retryBackoffFactor,
-                                     double retryMaxWaitInterval) {
+                                     double retryMaxWaitInterval, String listenerUrl, String listenerProtocol) {
         this.ballerinaRuntime = ballerinaRuntime;
         this.fileSystemManager = fileSystemManager;
         this.fileSystemOptions = fileSystemOptions;
@@ -103,6 +107,8 @@ public class FtpContentCallbackHandler {
         this.retryInterval = retryInterval;
         this.retryBackoffFactor = retryBackoffFactor;
         this.retryMaxWaitInterval = retryMaxWaitInterval;
+        this.listenerUrl = listenerUrl;
+        this.listenerProtocol = listenerProtocol;
     }
 
     /**
@@ -133,6 +139,9 @@ public class FtpContentCallbackHandler {
 
                 if (convertedContent instanceof BError bError) {
                     if (FtpUtil.ErrorType.ContentBindingError.errorType().equals(bError.getType().getName())) {
+                        FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
+                                FtpMetricsUtil.CONTEXT_LISTENER,
+                                FtpMetricsUtil.ERROR_TYPE_CONTENT_BINDING);
                         routeToOnError(service, holder, bError, callerObject, fileInfo, listenerPath,
                                 methodType.getName());
                     } else {
@@ -140,6 +149,9 @@ public class FtpContentCallbackHandler {
                     }
                     continue;
                 }
+
+                FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol,
+                        FtpMetricsUtil.EVENT_TYPE_CHANGE);
 
                 // Prepare method arguments
                 Object[] methodArguments = prepareContentMethodArguments(methodType, convertedContent,
@@ -149,9 +161,13 @@ public class FtpContentCallbackHandler {
                 Optional<PostProcessAction> afterProcess = holder.getAfterProcessAction(methodType.getName());
                 Optional<PostProcessAction> afterError = holder.getAfterErrorAction(methodType.getName());
 
+                Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
+                        FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
+                        FtpMetricsUtil.EVENT_TYPE_CHANGE, fileUri);
+
                 // Invoke method asynchronously with post-processing
                 invokeContentMethodAsync(service, methodType.getName(), methodArguments,
-                        fileInfo, callerObject, listenerPath, afterProcess, afterError);
+                        fileInfo, callerObject, listenerPath, afterProcess, afterError, strandProperties);
 
             } catch (Exception exception) {
                 FtpUtil.createError("Failed to process file: " + fileInfo.getPath() + " - " + exception.getMessage(),
@@ -325,11 +341,22 @@ public class FtpContentCallbackHandler {
         Optional<PostProcessAction> onErrorAfterError = holder.getAfterErrorAction(onErrorMethod.getName());
         boolean hasOnErrorActions = onErrorAfterProcess.isPresent() || onErrorAfterError.isPresent();
 
+        String errorType = error.getType() != null
+                ? FtpMetricsUtil.toObservabilityErrorType(error.getType().getName())
+                : FtpMetricsUtil.UNKNOWN;
+        FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
+                FtpMetricsUtil.CONTEXT_LISTENER, errorType);
+
+        Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
+                FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
+                FtpMetricsUtil.EVENT_TYPE_ERROR, fileInfo.getPath());
+
         Object[] methodArguments = prepareOnErrorMethodArguments(onErrorMethod, error, callerObject);
         invokeOnErrorMethodAsync(service, onErrorMethod.getName(), methodArguments, fileInfo, callerObject,
                 listenerPath,
                 hasOnErrorActions ? onErrorAfterProcess : Optional.empty(),
-                hasOnErrorActions ? onErrorAfterError : Optional.empty());
+                hasOnErrorActions ? onErrorAfterError : Optional.empty(),
+                strandProperties);
     }
 
     private Object[] prepareOnErrorMethodArguments(MethodType methodType, BError error, BObject callerObject) {
@@ -347,25 +374,34 @@ public class FtpContentCallbackHandler {
     private void invokeOnErrorMethodAsync(BObject service, String methodName, Object[] methodArguments,
                                           FileInfo fileInfo, BObject callerObject, String listenerPath,
                                           Optional<PostProcessAction> afterProcess,
-                                          Optional<PostProcessAction> afterError) {
+                                          Optional<PostProcessAction> afterError,
+                                          Map<String, Object> strandProperties) {
         Thread.startVirtualThread(() -> {
             boolean isSuccess = false;
             try {
                 ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
                 boolean isConcurrentSafe = serviceType.isIsolated() && serviceType.isIsolated(methodName);
-                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, null);
+                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, strandProperties);
 
                 Object result = ballerinaRuntime.callMethod(service, methodName, strandMetadata, methodArguments);
                 if (result instanceof BError) {
                     ((BError) result).printStackTrace();
+                    FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
+                            FtpMetricsUtil.CONTEXT_LISTENER,
+                            FtpMetricsUtil.toObservabilityErrorType(((BError) result).getType().getName()));
                 } else {
                     isSuccess = true;
                 }
             } catch (BError error) {
                 error.printStackTrace();
+                FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
+                        FtpMetricsUtil.CONTEXT_LISTENER,
+                        FtpMetricsUtil.toObservabilityErrorType(error.getType().getName()));
             } catch (Exception exception) {
                 FtpUtil.createError("Error invoking onError method: " + methodName + " - " + exception.getMessage(),
                         exception, FtpConstants.FTP_ERROR).printStackTrace();
+                FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
+                        FtpMetricsUtil.CONTEXT_LISTENER, FtpMetricsUtil.ERROR_TYPE_CONNECTION);
             }
 
             if (isSuccess) {
@@ -381,18 +417,22 @@ public class FtpContentCallbackHandler {
     private void invokeContentMethodAsync(BObject service, String methodName, Object[] methodArguments,
                                           FileInfo fileInfo, BObject callerObject, String listenerPath,
                                           Optional<PostProcessAction> afterProcess,
-                                          Optional<PostProcessAction> afterError) {
+                                          Optional<PostProcessAction> afterError,
+                                          Map<String, Object> strandProperties) {
         Thread.startVirtualThread(() -> {
             boolean isSuccess = false;
             try {
                 ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
                 boolean isConcurrentSafe = serviceType.isIsolated() && serviceType.isIsolated(methodName);
-                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, null);
+                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, strandProperties);
 
                 Object result = ballerinaRuntime.callMethod(service, methodName, strandMetadata, methodArguments);
 
                 if (result instanceof BError) {
                     ((BError) result).printStackTrace();
+                    FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
+                            FtpMetricsUtil.CONTEXT_LISTENER,
+                            FtpMetricsUtil.toObservabilityErrorType(((BError) result).getType().getName()));
                     // Method returned an error - execute afterError action
                     afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
                             listenerPath, ACTION_AFTER_ERROR));
@@ -401,12 +441,17 @@ public class FtpContentCallbackHandler {
                 }
             } catch (BError error) {
                 error.printStackTrace();
+                FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
+                        FtpMetricsUtil.CONTEXT_LISTENER,
+                        FtpMetricsUtil.toObservabilityErrorType(error.getType().getName()));
                 // Method threw an error - execute afterError action
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
                         listenerPath, ACTION_AFTER_ERROR));
             } catch (Exception exception) {
                 FtpUtil.createError("Error invoking content method: " + methodName + " - " + exception.getMessage(),
                         exception, FtpConstants.FTP_ERROR).printStackTrace();
+                FtpMetricsUtil.reportError(listenerUrl, listenerProtocol,
+                        FtpMetricsUtil.CONTEXT_LISTENER, FtpMetricsUtil.ERROR_TYPE_CONNECTION);
                 // Method threw an exception - execute afterError action
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
                         listenerPath, ACTION_AFTER_ERROR));

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
@@ -321,8 +321,9 @@ public class FtpListener implements RemoteFileSystemListener {
         Parameter[] params = methodType.getParameters();
         Object[] args = getMethodArguments(params, watchEventParamValues, caller);
         if (args != null) {
+            String traceEventType = event.getAddedFiles().isEmpty() ? EVENT_TYPE_DELETE : EVENT_TYPE_CHANGE;
             Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
-                    CONTEXT_LISTENER, listenerUrl, listenerProtocol, EVENT_TYPE_CHANGE);
+                    CONTEXT_LISTENER, listenerUrl, listenerProtocol, traceEventType);
             invokeMethodAsync(service, strandProperties, args);
         }
     }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
@@ -68,9 +68,11 @@ import static io.ballerina.runtime.api.types.TypeTags.RECORD_TYPE_TAG;
 import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.CONTEXT_LISTENER;
 import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.EVENT_TYPE_CHANGE;
 import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.EVENT_TYPE_DELETE;
+import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.EVENT_TYPE_ERROR;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_SERVER_EVENT;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_WATCHEVENT_ADDED_FILES;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_WATCHEVENT_DELETED_FILES;
+import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_ERROR_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_CHANGE_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_DELETE_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_DELETED_REMOTE_FUNCTION;
@@ -521,6 +523,8 @@ public class FtpListener implements RemoteFileSystemListener {
         log.error(throwable.getMessage(), throwable);
         FtpMetricsUtil.reportError(listenerUrl, listenerProtocol, CONTEXT_LISTENER,
                 FtpMetricsUtil.toObservabilityErrorType(throwable));
+        FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_ERROR,
+                ON_ERROR_REMOTE_FUNCTION, ON_ERROR_REMOTE_FUNCTION);
     }
 
     @Override

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
@@ -39,7 +39,6 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.ftp.exception.FtpInvalidConfigException;
 import io.ballerina.stdlib.ftp.exception.RemoteFileSystemConnectorException;
-import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
 import io.ballerina.stdlib.ftp.observability.FtpTracingUtil;
 import io.ballerina.stdlib.ftp.transport.listener.RemoteFileSystemListener;
 import io.ballerina.stdlib.ftp.transport.message.FileInfo;
@@ -68,11 +67,9 @@ import static io.ballerina.runtime.api.types.TypeTags.RECORD_TYPE_TAG;
 import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.CONTEXT_LISTENER;
 import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.EVENT_TYPE_CHANGE;
 import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.EVENT_TYPE_DELETE;
-import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.EVENT_TYPE_ERROR;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_SERVER_EVENT;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_WATCHEVENT_ADDED_FILES;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_WATCHEVENT_DELETED_FILES;
-import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_ERROR_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_CHANGE_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_DELETE_REMOTE_FUNCTION;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.ON_FILE_DELETED_REMOTE_FUNCTION;
@@ -264,8 +261,6 @@ public class FtpListener implements RemoteFileSystemListener {
 
         // Call onFileDelete once per deleted file
         for (String deletedFile : deletedFilesList) {
-            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE,
-                    ON_FILE_DELETE_REMOTE_FUNCTION, ON_FILE_DELETE_REMOTE_FUNCTION);
             BString deletedFileBString = StringUtils.fromString(deletedFile);
             Object[] args = getOnFileDeleteMethodArguments(params, deletedFileBString, caller);
             if (args != null) {
@@ -285,8 +280,6 @@ public class FtpListener implements RemoteFileSystemListener {
         BString[] deletedFilesBStringArray = new BString[deletedFilesList.size()];
         for (int i = 0; i < deletedFilesList.size(); i++) {
             String deletedFile = deletedFilesList.get(i);
-            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE,
-                    ON_FILE_DELETED_REMOTE_FUNCTION, ON_FILE_DELETED_REMOTE_FUNCTION);
             deletedFilesBStringArray[i] = StringUtils.fromString(deletedFile);
         }
 
@@ -307,16 +300,6 @@ public class FtpListener implements RemoteFileSystemListener {
      */
     private void processMetadataOnlyCallbacks(BObject service, RemoteFileSystemEvent event,
                                               MethodType methodType, BObject caller) {
-        // Report a "change" event per added file and a "delete" event per deleted file
-        for (int i = 0; i < event.getAddedFiles().size(); i++) {
-            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_CHANGE,
-                    ON_FILE_CHANGE_REMOTE_FUNCTION, ON_FILE_CHANGE_REMOTE_FUNCTION);
-        }
-        for (String deletedFile : event.getDeletedFiles()) {
-            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE,
-                    ON_FILE_CHANGE_REMOTE_FUNCTION, ON_FILE_CHANGE_REMOTE_FUNCTION);
-        }
-
         Map<String, Object> watchEventParamValues = processWatchEventParamValues(event);
         Parameter[] params = methodType.getParameters();
         Object[] args = getMethodArguments(params, watchEventParamValues, caller);
@@ -522,10 +505,6 @@ public class FtpListener implements RemoteFileSystemListener {
     @Override
     public void onError(Throwable throwable) {
         log.error(throwable.getMessage(), throwable);
-        FtpMetricsUtil.reportError(listenerUrl, listenerProtocol, CONTEXT_LISTENER,
-                FtpMetricsUtil.toObservabilityErrorType(throwable));
-        FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_ERROR,
-                ON_ERROR_REMOTE_FUNCTION, ON_ERROR_REMOTE_FUNCTION);
     }
 
     @Override

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
@@ -39,6 +39,8 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.ftp.exception.FtpInvalidConfigException;
 import io.ballerina.stdlib.ftp.exception.RemoteFileSystemConnectorException;
+import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
+import io.ballerina.stdlib.ftp.observability.FtpTracingUtil;
 import io.ballerina.stdlib.ftp.transport.listener.RemoteFileSystemListener;
 import io.ballerina.stdlib.ftp.transport.message.FileInfo;
 import io.ballerina.stdlib.ftp.transport.message.RemoteFileSystemBaseMessage;
@@ -63,6 +65,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.ballerina.runtime.api.types.TypeTags.OBJECT_TYPE_TAG;
 import static io.ballerina.runtime.api.types.TypeTags.RECORD_TYPE_TAG;
+import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.CONTEXT_LISTENER;
+import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.EVENT_TYPE_CHANGE;
+import static io.ballerina.stdlib.ftp.observability.FtpMetricsUtil.EVENT_TYPE_DELETE;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_SERVER_EVENT;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_WATCHEVENT_ADDED_FILES;
 import static io.ballerina.stdlib.ftp.util.FtpConstants.FTP_WATCHEVENT_DELETED_FILES;
@@ -90,6 +95,8 @@ public class FtpListener implements RemoteFileSystemListener {
     private FileSystemOptions fileSystemOptions;
     private boolean laxDataBinding;
     private String legacyListenerPath;
+    private String listenerUrl;
+    private String listenerProtocol;
     private BMap<?, ?> csvFailSafe = ValueCreator.createMapValue();
     private boolean retryEnabled = false;
     private long retryCount = 0;
@@ -205,7 +212,8 @@ public class FtpListener implements RemoteFileSystemListener {
                 try {
                     FtpContentCallbackHandler contentHandler = new FtpContentCallbackHandler(
                             runtime, fileSystemManager, fileSystemOptions, laxDataBinding, csvFailSafe,
-                            retryEnabled, retryCount, retryInterval, retryBackoffFactor, retryMaxWaitInterval);
+                            retryEnabled, retryCount, retryInterval, retryBackoffFactor, retryMaxWaitInterval,
+                            listenerUrl, listenerProtocol);
                     contentHandler.processContentCallbacks(env, service, event, holder, caller);
                 } catch (Exception e) {
                     FtpUtil.createError("Error in content callback processing for added files: " + e.getMessage(),
@@ -254,10 +262,13 @@ public class FtpListener implements RemoteFileSystemListener {
 
         // Call onFileDelete once per deleted file
         for (String deletedFile : deletedFilesList) {
+            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE);
             BString deletedFileBString = StringUtils.fromString(deletedFile);
             Object[] args = getOnFileDeleteMethodArguments(params, deletedFileBString, caller);
             if (args != null) {
-                invokeOnFileDeleteAsync(service, args);
+                Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
+                        CONTEXT_LISTENER, listenerUrl, listenerProtocol, EVENT_TYPE_DELETE, deletedFile);
+                invokeOnFileDeleteAsync(service, strandProperties, args);
             }
         }
     }
@@ -270,7 +281,9 @@ public class FtpListener implements RemoteFileSystemListener {
         List<String> deletedFilesList = event.getDeletedFiles();
         BString[] deletedFilesBStringArray = new BString[deletedFilesList.size()];
         for (int i = 0; i < deletedFilesList.size(); i++) {
-            deletedFilesBStringArray[i] = StringUtils.fromString(deletedFilesList.get(i));
+            String deletedFile = deletedFilesList.get(i);
+            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE);
+            deletedFilesBStringArray[i] = StringUtils.fromString(deletedFile);
         }
 
         // Create string array for deleted files
@@ -279,7 +292,9 @@ public class FtpListener implements RemoteFileSystemListener {
         Parameter[] params = methodType.getParameters();
         Object[] args = getOnFileDeletedMethodArguments(params, deletedFilesArray, caller);
         if (args != null) {
-            invokeOnFileDeletedAsync(service, args);
+            Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
+                    CONTEXT_LISTENER, listenerUrl, listenerProtocol, EVENT_TYPE_DELETE);
+            invokeOnFileDeletedAsync(service, strandProperties, args);
         }
     }
 
@@ -288,11 +303,21 @@ public class FtpListener implements RemoteFileSystemListener {
      */
     private void processMetadataOnlyCallbacks(BObject service, RemoteFileSystemEvent event,
                                               MethodType methodType, BObject caller) {
+        // Report a "change" event per added file and a "delete" event per deleted file
+        for (int i = 0; i < event.getAddedFiles().size(); i++) {
+            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_CHANGE);
+        }
+        for (String deletedFile : event.getDeletedFiles()) {
+            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE);
+        }
+
         Map<String, Object> watchEventParamValues = processWatchEventParamValues(event);
         Parameter[] params = methodType.getParameters();
         Object[] args = getMethodArguments(params, watchEventParamValues, caller);
         if (args != null) {
-            invokeMethodAsync(service, args);
+            Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
+                    CONTEXT_LISTENER, listenerUrl, listenerProtocol, EVENT_TYPE_CHANGE);
+            invokeMethodAsync(service, strandProperties, args);
         }
     }
 
@@ -334,13 +359,13 @@ public class FtpListener implements RemoteFileSystemListener {
         return null;
     }
 
-    private void invokeOnFileDeleteAsync(BObject service, Object ...args) {
+    private void invokeOnFileDeleteAsync(BObject service, Map<String, Object> strandProperties, Object ...args) {
         Thread.startVirtualThread(() -> {
             try {
                 ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
                 boolean isConcurrentSafe = serviceType.isIsolated() &&
                         serviceType.isIsolated(ON_FILE_DELETE_REMOTE_FUNCTION);
-                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, null);
+                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, strandProperties);
                 Object result = runtime.callMethod(service, ON_FILE_DELETE_REMOTE_FUNCTION, strandMetadata, args);
                 if (result instanceof BError) {
                     ((BError) result).printStackTrace();
@@ -351,13 +376,13 @@ public class FtpListener implements RemoteFileSystemListener {
         });
     }
 
-    private void invokeOnFileDeletedAsync(BObject service, Object ...args) {
+    private void invokeOnFileDeletedAsync(BObject service, Map<String, Object> strandProperties, Object ...args) {
         Thread.startVirtualThread(() -> {
             try {
                 ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
                 boolean isConcurrentSafe = serviceType.isIsolated() &&
                         serviceType.isIsolated(ON_FILE_DELETED_REMOTE_FUNCTION);
-                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, null);
+                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, strandProperties);
                 Object result = runtime.callMethod(service, ON_FILE_DELETED_REMOTE_FUNCTION, strandMetadata, args);
                 if (result instanceof BError) {
                     ((BError) result).printStackTrace();
@@ -368,13 +393,13 @@ public class FtpListener implements RemoteFileSystemListener {
         });
     }
 
-    private void invokeMethodAsync(BObject service, Object ...args) {
+    private void invokeMethodAsync(BObject service, Map<String, Object> strandProperties, Object ...args) {
         Thread.startVirtualThread(() -> {
             try {
                 ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
                 boolean isConcurrentSafe = serviceType.isIsolated() &&
                         serviceType.isIsolated(ON_FILE_CHANGE_REMOTE_FUNCTION);
-                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, null);
+                StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, strandProperties);
                 Object result = runtime.callMethod(service, ON_FILE_CHANGE_REMOTE_FUNCTION, strandMetadata, args);
                 if (result instanceof BError) {
                     ((BError) result).printStackTrace();
@@ -383,7 +408,6 @@ public class FtpListener implements RemoteFileSystemListener {
                 error.printStackTrace();
             }
         });
-
     }
 
     private BMap<BString, Object> getWatchEvent(Parameter parameter, Map<String, Object> parameters) {
@@ -491,6 +515,8 @@ public class FtpListener implements RemoteFileSystemListener {
     @Override
     public void onError(Throwable throwable) {
         log.error(throwable.getMessage(), throwable);
+        FtpMetricsUtil.reportError(listenerUrl, listenerProtocol, CONTEXT_LISTENER,
+                FtpMetricsUtil.toObservabilityErrorType(throwable));
     }
 
     @Override
@@ -624,6 +650,22 @@ public class FtpListener implements RemoteFileSystemListener {
         this.legacyListenerPath = legacyListenerPath;
     }
 
+    public void setListenerUrl(String listenerUrl) {
+        this.listenerUrl = listenerUrl;
+    }
+
+    public String getListenerUrl() {
+        return listenerUrl;
+    }
+
+    public void setListenerProtocol(String listenerProtocol) {
+        this.listenerProtocol = listenerProtocol;
+    }
+
+    public String getListenerProtocol() {
+        return listenerProtocol;
+    }
+
     void cleanup() {
         serviceContexts.clear();
         usesServiceLevelConfig.set(false);
@@ -632,6 +674,8 @@ public class FtpListener implements RemoteFileSystemListener {
         fileSystemManager = null;
         fileSystemOptions = null;
         legacyListenerPath = null;
+        listenerUrl = null;
+        listenerProtocol = null;
         retryEnabled = false;
         retryCount = 0;
         retryInterval = 0;

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
@@ -262,7 +262,8 @@ public class FtpListener implements RemoteFileSystemListener {
 
         // Call onFileDelete once per deleted file
         for (String deletedFile : deletedFilesList) {
-            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE);
+            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE,
+                    ON_FILE_DELETE_REMOTE_FUNCTION, ON_FILE_DELETE_REMOTE_FUNCTION);
             BString deletedFileBString = StringUtils.fromString(deletedFile);
             Object[] args = getOnFileDeleteMethodArguments(params, deletedFileBString, caller);
             if (args != null) {
@@ -282,7 +283,8 @@ public class FtpListener implements RemoteFileSystemListener {
         BString[] deletedFilesBStringArray = new BString[deletedFilesList.size()];
         for (int i = 0; i < deletedFilesList.size(); i++) {
             String deletedFile = deletedFilesList.get(i);
-            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE);
+            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE,
+                    ON_FILE_DELETED_REMOTE_FUNCTION, ON_FILE_DELETED_REMOTE_FUNCTION);
             deletedFilesBStringArray[i] = StringUtils.fromString(deletedFile);
         }
 
@@ -305,10 +307,12 @@ public class FtpListener implements RemoteFileSystemListener {
                                               MethodType methodType, BObject caller) {
         // Report a "change" event per added file and a "delete" event per deleted file
         for (int i = 0; i < event.getAddedFiles().size(); i++) {
-            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_CHANGE);
+            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_CHANGE,
+                    ON_FILE_CHANGE_REMOTE_FUNCTION, ON_FILE_CHANGE_REMOTE_FUNCTION);
         }
         for (String deletedFile : event.getDeletedFiles()) {
-            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE);
+            FtpMetricsUtil.reportFileEvent(listenerUrl, listenerProtocol, EVENT_TYPE_DELETE,
+                    ON_FILE_CHANGE_REMOTE_FUNCTION, ON_FILE_CHANGE_REMOTE_FUNCTION);
         }
 
         Map<String, Object> watchEventParamValues = processWatchEventParamValues(event);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
@@ -947,8 +947,10 @@ public class FtpListenerHelper {
             if (listener != null) {
                 listener.cleanup();
             }
-            FtpMetricsUtil.reportConnectionClose(listenerUrl, listenerProtocol,
-                    FtpMetricsUtil.CONTEXT_LISTENER);
+            if (ftpConnector != null) {
+                FtpMetricsUtil.reportConnectionClose(listenerUrl, listenerProtocol,
+                        FtpMetricsUtil.CONTEXT_LISTENER);
+            }
         }
         return null;
     }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
@@ -36,6 +36,7 @@ import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.ftp.exception.BallerinaFtpException;
 import io.ballerina.stdlib.ftp.exception.FtpInvalidConfigException;
 import io.ballerina.stdlib.ftp.exception.RemoteFileSystemConnectorException;
+import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
 import io.ballerina.stdlib.ftp.transport.RemoteFileSystemConnectorFactory;
 import io.ballerina.stdlib.ftp.transport.impl.RemoteFileSystemConnectorFactoryImpl;
 import io.ballerina.stdlib.ftp.transport.server.FileDependencyCondition;
@@ -132,6 +133,17 @@ public class FtpListenerHelper {
             ftpListener.addNativeData(BASE_PARAMS_KEY, paramMap);
             ftpListener.addNativeData(FTP_LISTENER_KEY, listener);
             ftpListener.addNativeData(FTP_SERVICE_ENDPOINT_CONFIG, serviceEndpointConfig);
+
+            String host = serviceEndpointConfig
+                    .getStringValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_HOST)).getValue();
+            int port = FtpUtil.extractPortValue(serviceEndpointConfig
+                    .getIntValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_PORT)));
+            String protocol = serviceEndpointConfig
+                    .getStringValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_PROTOCOL)).getValue();
+            String url = protocol + "://" + host + ":" + port;
+            listener.setListenerUrl(url);
+            listener.setListenerProtocol(protocol);
+
             // No connector created yet - deferred to register()
             return null;
         } catch (FtpInvalidConfigException e) {
@@ -206,6 +218,8 @@ public class FtpListenerHelper {
                             findRootCause(e), Error.errorType());
                 }
             }
+            FtpMetricsUtil.reportNewConnection(listener.getListenerUrl(), listener.getListenerProtocol(),
+                    FtpMetricsUtil.CONTEXT_LISTENER);
         } else {
             // Subsequent service registration - validate consistency
             boolean previousUsesConfig = listener.usesServiceLevelConfig();
@@ -919,6 +933,9 @@ public class FtpListenerHelper {
         FtpListener listener = ftpConnector != null
                 ? ftpConnector.getFtpListener()
                 : (FtpListener) ftpListener.getNativeData(FTP_LISTENER_KEY);
+        // Capture observability data before cleanup clears the listener fields
+        String listenerUrl = listener != null ? listener.getListenerUrl() : null;
+        String listenerProtocol = listener != null ? listener.getListenerProtocol() : null;
         try {
             closeCaller(env, ftpListener);
             if (ftpConnector != null) {
@@ -930,6 +947,8 @@ public class FtpListenerHelper {
             if (listener != null) {
                 listener.cleanup();
             }
+            FtpMetricsUtil.reportConnectionClose(listenerUrl, listenerProtocol,
+                    FtpMetricsUtil.CONTEXT_LISTENER);
         }
         return null;
     }


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8790

This PR introduces built-in metrics and distributed tracing support to the Ballerina FTP library. When observability is enabled in the Ballerina runtime, the FTP client and listener automatically report telemetry data with no additional configuration required.

## Summary                                                                                                                         
                                                                                                                                   
  - Add observability support for the FTP client and listener                                                                        
    ([ballerina-platform/ballerina-library#8790](https://github.com/ballerina-platform/ballerina-library/issues/8790))               
  - Introduce `ftp_active_connections` gauge metric tracking live FTP/FTPS/SFTP connections across clients and listeners             
  - Instrument all client operations and listener file events with trace spans carrying structured tags (`context`, `protocol`,    
    `remote.url`, `operation.type`, `event.type`, `error.type`, etc.) that integrate with the Ballerina framework's built-in         
    `requests_total_value` metric                                                                                                  
                                                                                                                                     
  **Metrics**                                                                                                                      
  - `ftp_active_connections` (Gauge) — incremented on client/listener init, decremented on close (including on close errors)
  - Operation and event counts are derived from the framework's `requests_total_value` by filtering on the tags emitted per span     
   
  **Tracing**                                                                                                                        
  - Client spans: tagged with `context=client`, `action.type=operation`, `operation.type` (`get`, `put`, `admin`), `file.path`     
  - Listener spans: tagged with `context=listener`, `action.type=event`, `event.type` (`create`, `delete`, `error`), and `error.type`
   when                                                                                                                              
    dispatched to `onError`
                                                                                                                                     
  | Tag | Possible Values | Present On |                                                                                           
  |---|---|---|
  | `context` | `client`, `listener` | All spans |
  | `action.type` | `operation`, `event` | All spans |
  | `remote.url` | `host:port` of the remote server | All spans |                                                                    
  | `protocol` | `ftp`, `ftps`, `sftp` | All spans |
  | `host` | Hostname of the current node | All spans |                                                                              
  | `operation.type` | `get`, `put`, `admin` | `action.type=operation` spans only |                                                  
  | `event.type` | `create`, `delete`, `error` | `action.type=event` spans only |
  | `error.type` | `ConnectionError`, `AuthenticationError`, `FileNotFoundError`, `FileAlreadyExistsError`, `ServiceUnavailableError`, `ContentBindingError`, `RetryError`, `CircuitBreakerOpenError`, `InvalidConfigError`, `CloseError`  |    
  `event.type=error` spans only |
  | `file.path` | Source/target file path of the operation | Traces only (excluded from metrics) |                                   
  | `destination.path` | Destination path for two-path operations (`rename`, `move`, `copy`) | Traces only (excluded from metrics) |