### PR TITLE
Honor SFTP proxy.type for SOCKS5/STREAM instead of forcing HTTP

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - [Add observability support for the FTP client and listener](https://github.com/ballerina-platform/ballerina-library/issues/8790)
 
+### Fixed
+
+- [Honor the configured SFTP `proxy.type` (`SOCKS5`/`STREAM`) instead of always using an HTTP proxy](https://github.com/ballerina-platform/ballerina-library/issues/8831)
+
 ## [2.19.0] - 2026-04-27
 
 ### Added

--- a/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/transport/server/util/FileTransportUtils.java
@@ -432,8 +432,30 @@ public final class FileTransportUtils {
                 configBuilder.setProxyHost(opts, proxyHost);
                 configBuilder.setProxyPort(opts, proxyPort);
 
-                // Set proxy type if supported (HTTP/SOCKS)
-                configBuilder.setProxyType(opts, SftpFileSystemConfigBuilder.PROXY_HTTP);
+                // Map the configured proxy type to the corresponding VFS proxy type. Commons VFS
+                // supports HTTP, SOCKS5 and STREAM; anything else falls back to HTTP.
+                SftpFileSystemConfigBuilder.ProxyType vfsProxyType;
+                switch (proxyType) {
+                    case FtpConstants.PROXY_TYPE_SOCKS5:
+                        vfsProxyType = SftpFileSystemConfigBuilder.PROXY_SOCKS5;
+                        break;
+                    case FtpConstants.PROXY_TYPE_STREAM:
+                        vfsProxyType = SftpFileSystemConfigBuilder.PROXY_STREAM;
+                        break;
+                    case FtpConstants.PROXY_TYPE_HTTP:
+                    default:
+                        vfsProxyType = SftpFileSystemConfigBuilder.PROXY_HTTP;
+                        break;
+                }
+                configBuilder.setProxyType(opts, vfsProxyType);
+
+                // STREAM proxy connects through an external command (e.g. an SSH jump host).
+                if (FtpConstants.PROXY_TYPE_STREAM.equals(proxyType)) {
+                    Object proxyCommandObj = options.get(FtpConstants.PROXY_COMMAND);
+                    if (proxyCommandObj != null && !proxyCommandObj.toString().isEmpty()) {
+                        configBuilder.setProxyCommand(opts, proxyCommandObj.toString());
+                    }
+                }
 
                 // Set proxy authentication if provided
                 Object proxyUsernameObj = options.get(FtpConstants.PROXY_USERNAME);


### PR DESCRIPTION
## Purpose

Fixes ballerina-platform/ballerina-library#8831

The SFTP `proxy.type` (`SOCKS5`/`STREAM`) was ignored — the transport always configured Commons VFS with an HTTP CONNECT proxy, so SOCKS5 proxying never worked and `STREAM` was also broken.

## Root cause

In `FileTransportUtils.java`, the configured proxy type was parsed but `setProxyType(...)` was hardcoded to `SftpFileSystemConfigBuilder.PROXY_HTTP` (the parsed value was only logged). Additionally, `setProxyCommand(...)` was never called, so the `STREAM` proxy `command` was dropped.

## Fix

- Map `proxy.type` to the corresponding VFS type: `HTTP` → `PROXY_HTTP`, `SOCKS5` → `PROXY_SOCKS5`, `STREAM` → `PROXY_STREAM` (unknown → HTTP fallback).
- Apply the `STREAM` proxy `command` via `setProxyCommand`.

SOCKS4 is intentionally not supported: Commons VFS 2.10.0 only exposes `PROXY_HTTP`/`PROXY_SOCKS5`/`PROXY_STREAM`, and the `ftp:ProxyType` enum already omits SOCKS4. No public API change.

## Testing

Verified end-to-end with a Docker blackbox harness (atmoz/sftp reachable **only** through a proxy on an isolated network; a SOCKS5 proxy, a SOCKS5+auth proxy, and an HTTP CONNECT proxy):

| Case | Before | After |
|---|---|---|
| `type=HTTP` via HTTP proxy | PASS | PASS |
| `type=SOCKS5` via SOCKS5 proxy | FAIL (`ProxyHTTP: IOException`; proxy logged `Unsupported SOCKS version: [67]`) | **PASS** |
| `type=SOCKS5` via HTTP proxy (mismatch) | PASS (bug — downgraded to HTTP) | **FAIL** (type now honored) |
| `type=SOCKS5` + auth via SOCKS5 auth proxy | FAIL | **PASS** |

The full `ballerina-tests` regression suite passes (no proxy-path test exists in the suite — the in-process MINA test server has no proxy support — so automated coverage of the proxy path is out of scope here; validation was the manual Docker harness).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes an issue where SFTP client proxy configuration was not honoring the configured `proxy.type` setting. Previously, the proxy type was parsed from configuration but then disregarded, with the system always defaulting to HTTP proxy behavior regardless of the user's specified type.

## Changes

**FileTransportUtils.java**: Updated the SFTP proxy configuration logic in `setSftpOptions` to:
- Map the configured proxy type (HTTP, SOCKS5, STREAM) to the corresponding Apache Commons VFS proxy type implementation
- Apply the STREAM proxy command when a STREAM proxy type is configured with a command value
- Ensure the configured proxy type is actually used instead of defaulting to HTTP for all cases

**changelog.md**: Added entry documenting that SFTP now properly honors the configured `proxy.type` parameter.

## Outcome

SFTP clients can now properly use different proxy types (SOCKS5, HTTP, STREAM) as specified in their configuration, improving flexibility and compatibility with various proxy infrastructure setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->