### PR TITLE
Rewrite the library specification

### DIFF
--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -122,7 +122,9 @@ public type PrivateKey record {|
 
 #### 2.1.3 Anonymous Authentication
 
-Omitting `auth` entirely connects anonymously.
+Omitting `auth` does not skip authentication. The username defaults to `anonymous`, with an empty password on FTP and FTPS and none on SFTP.
+
+On an FTP or FTPS server that permits anonymous login, that is the anonymous connection. **SFTP has no anonymous mode**: the SSH login is attempted as user `anonymous`, and a server that does not know that user rejects it.
 
 ### 2.2 SFTP Authentication Methods
 
@@ -350,6 +352,8 @@ public enum FileWriteOption {
 
 A write creates the file when it is not there. `putText` and `putJson` encode as UTF-8.
 
+`record {}` carries an `anydata` rest field, so the record accepted by `putJson` and `putXml` is wider than the content each one writes. `putJson` serializes whatever it is given with `toJsonString`, and `putXml` returns an `ftp:Error` when `xmldata:toXml` cannot convert the record.
+
 `putCsv` writes a header row taken from the record field names when the content is a `record {}[]` and the option is not `APPEND`. Appending a `record {}[]` writes data rows only, so a file built entirely by appends has no header. A `string[][]` never gets a header row; whatever the first row holds is written as-is.
 
 The streaming writes take a stream instead of a value in memory, which is what a file too large to hold needs.
@@ -376,7 +380,7 @@ check ftpClient->putBytesAsStream("/uploads/data.bin", fileStream);
 | `getXml` | `xml` or `record {}` |
 | `getCsv` | `string[][]` or `record {}[]` |
 | `getBytesAsStream` | `stream<byte[], error?>` |
-| `getCsvAsStream` | a stream of `string[]` or `record {}` |
+| `getCsvAsStream` | `stream<string[]\|record {}, error?>` |
 
 Reading a path that is not there gives an `ftp:FileNotFoundError`.
 
@@ -679,10 +683,10 @@ A service declares one or more content handlers. The listener reads the file, bi
 | `onFileText` | `string` |
 | `onFileJson` | `json` or `record {}` |
 | `onFileXml` | `xml` or `record {}` |
-| `onFileCsv` | `string[][]`, `record {}[]`, or a stream of either |
+| `onFileCsv` | `string[][]`, `record {}[]`, `stream<string[], error?>`, or `stream<record {}, error?>` |
 | `onFile` | `byte[]`, or a `stream<byte[], error?>` |
 
-Declaring a stream as the content parameter of `onFileCsv` or `onFile` streams the file instead of holding it in memory.
+Declaring a stream as the content parameter of `onFileCsv` or `onFile` streams the file instead of holding it in memory. **A handler that declares a stream must consume or close it**, since the file stays open until the stream reaches its end or is closed.
 
 After the content parameter, a handler may declare an `ftp:FileInfo` parameter, then an `ftp:Caller` parameter. Both are optional, but **the order is fixed**: `ftp:FileInfo` second, `ftp:Caller` third. A handler returns `error?` or `ftp:Error?`.
 
@@ -725,7 +729,7 @@ When the handler for an extension is not declared, the file goes to `onFile`. A 
 
 Filtering decides which files the listener picks up at all, and is separate from the routing of [Section 4.4](#44-handler-selection). A file the filters reject reaches no handler.
 
-`fileNamePattern` on `@ftp:ServiceConfig` is a Java regular expression matched against the whole file name. Only files that match are picked up. Without it, every file in the directory is picked up. A `fileNamePattern` on a handler narrows this no further; the service-level pattern has already decided what the poll sees.
+`fileNamePattern` on `@ftp:ServiceConfig` is a Java regular expression matched against the whole file name. Only files that match are picked up. Without it, every file in the directory is picked up. A `fileNamePattern` on a handler narrows this no further; the active service-level pattern, or the deprecated listener-level pattern when no service annotation is used, has already decided what the poll sees.
 
 `fileAgeFilter` skips files by age.
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -21,6 +21,9 @@ The implementation that matches this specification is released with the distribu
 1. [Overview](#1-overview)
 2. [Security](#2-security)
    * 2.1 [Authentication](#21-authentication)
+     * 2.1.1 [Password Authentication](#211-password-authentication)
+     * 2.1.2 [Public Key Authentication](#212-public-key-authentication)
+     * 2.1.3 [Anonymous Authentication](#213-anonymous-authentication)
    * 2.2 [SFTP Authentication Methods](#22-sftp-authentication-methods)
    * 2.3 [SFTP Host Key Verification](#23-sftp-host-key-verification)
    * 2.4 [FTPS Transport Security](#24-ftps-transport-security)
@@ -58,11 +61,11 @@ The library has three parts.
 
 | Part | What it does |
 | --- | --- |
-| `ftp:Client` | Reads, writes, moves, copies, and lists files on a server |
-| `ftp:Listener` | Polls a directory on a server and hands each file that arrives or disappears to a service |
-| `ftp:Caller` | A server connection given to a handler, so it can act on the server while processing a file |
+| `ftp:Client` | Performs file system operations on an FTP, FTPS, or SFTP server |
+| `ftp:Listener` | Polls a directory on a server and triggers on file changes |
+| `ftp:Caller` | Provides server access to an `ftp:Service` handler for file operations |
 
-One connection speaks one protocol, chosen by the `protocol` field.
+A connection is bound to a single protocol, chosen by the `protocol` field.
 
 ```ballerina
 public enum Protocol {
@@ -93,6 +96,10 @@ public type AuthConfiguration record {|
 |};
 ```
 
+`secureSocket` configures TLS and applies to FTPS only; see [Section 2.4](#24-ftps-transport-security). When both `credentials` and `privateKey` are present, `preferredMethods` decides which is offered first.
+
+#### 2.1.1 Password Authentication
+
 `credentials` is a username with an optional password. The password is optional because public key authentication needs the username alone.
 
 ```ballerina
@@ -101,6 +108,8 @@ public type Credentials record {|
     string password?;
 |};
 ```
+
+#### 2.1.2 Public Key Authentication
 
 `privateKey` is an SSH key for SFTP. `password` decrypts the key file when the key is encrypted.
 
@@ -111,7 +120,9 @@ public type PrivateKey record {|
 |};
 ```
 
-`secureSocket` configures TLS and applies to FTPS only; see [Section 2.4](#24-ftps-transport-security). Omitting `auth` entirely connects anonymously.
+#### 2.1.3 Anonymous Authentication
+
+Omitting `auth` entirely connects anonymously.
 
 ### 2.2 SFTP Authentication Methods
 
@@ -221,7 +232,9 @@ ftp:Client ftpsClient = check new ({
 
 ### 3.1 Initializing the Client
 
-Every field has a default, so a client for a local server on the standard port needs no configuration at all.
+The `ftp:Client` is initialized using an `ftp:ClientConfiguration` record. Every field has a default, so a client for a local server on the standard port needs no configuration at all.
+
+The `protocol`, `host`, and `port` identify the server, while `auth` says who connects and `userDirIsRoot` says what its root is. Data binding, timeouts, proxying, transfer mode, compression, host key verification, retry, and the circuit breaker can be configured through the other fields.
 
 ```ballerina
 public type ClientConfiguration record {|
@@ -256,6 +269,10 @@ ftp:Client ftpClient = check new ({
 ```
 
 `close` releases the connection.
+
+```ballerina
+check ftpClient->close();
+```
 
 ### 3.2 Transport Options
 
@@ -316,8 +333,8 @@ public enum ProxyType {
 | --- | --- |
 | `putBytes` | `byte[]` |
 | `putText` | `string` |
-| `putJson` | `json`, or a record |
-| `putXml` | `xml`, or a record |
+| `putJson` | `json` or `record {}` |
+| `putXml` | `xml` or `record {}` |
 | `putCsv` | `string[][]` or `record {}[]` |
 | `putBytesAsStream` | `stream<byte[], error?>` |
 | `putCsvAsStream` | `stream<string[]\|record {}, error?>` |
@@ -333,7 +350,7 @@ public enum FileWriteOption {
 
 A write creates the file when it is not there. `putText` and `putJson` encode as UTF-8.
 
-`putCsv` writes a header row taken from the record field names when the content is a `record {}[]` and the option is not `APPEND`. Appending a record array writes data rows only, so a file built entirely by appends has no header. A `string[][]` never gets a header row; whatever the first row holds is written as-is.
+`putCsv` writes a header row taken from the record field names when the content is a `record {}[]` and the option is not `APPEND`. Appending a `record {}[]` writes data rows only, so a file built entirely by appends has no header. A `string[][]` never gets a header row; whatever the first row holds is written as-is.
 
 The streaming writes take a stream instead of a value in memory, which is what a file too large to hold needs.
 
@@ -355,11 +372,11 @@ check ftpClient->putBytesAsStream("/uploads/data.bin", fileStream);
 | --- | --- |
 | `getBytes` | `byte[]` |
 | `getText` | `string` |
-| `getJson` | the `json` or record type expected at the call site |
-| `getXml` | the `xml` or record type expected at the call site |
-| `getCsv` | `string[][]`, or the `record {}[]` type expected at the call site |
+| `getJson` | `json` or `record {}` |
+| `getXml` | `xml` or `record {}` |
+| `getCsv` | `string[][]` or `record {}[]` |
 | `getBytesAsStream` | `stream<byte[], error?>` |
-| `getCsvAsStream` | a stream of `string[]`, or of the record type expected at the call site |
+| `getCsvAsStream` | a stream of `string[]` or `record {}` |
 
 Reading a path that is not there gives an `ftp:FileNotFoundError`.
 
@@ -660,9 +677,9 @@ A service declares one or more content handlers. The listener reads the file, bi
 | Handler | Content parameter |
 | --- | --- |
 | `onFileText` | `string` |
-| `onFileJson` | `json`, or a record type the JSON content binds to |
-| `onFileXml` | `xml`, or a record type |
-| `onFileCsv` | `string[][]`, a record array type, or a stream of either |
+| `onFileJson` | `json` or `record {}` |
+| `onFileXml` | `xml` or `record {}` |
+| `onFileCsv` | `string[][]`, `record {}[]`, or a stream of either |
 | `onFile` | `byte[]`, or a `stream<byte[], error?>` |
 
 Declaring a stream as the content parameter of `onFileCsv` or `onFile` streams the file instead of holding it in memory.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,65 +3,49 @@
 _Owners_: @shafreenAnfar @dilanSachi @Bhashinee \
 _Reviewers_: @shafreenAnfar @Bhashinee \
 _Created_: 2020/10/28 \
-_Updated_: 2026/05/20 \
+_Updated_: 2026/08/19 \
 _Edition_: Swan Lake
 
 ## Introduction
 
-This is the specification for the FTP standard library of the [Ballerina language](https://ballerina.io/), which provides FTP client and listener functionalities to send and receive files by connecting to FTP/SFTP servers.
+This is the specification for the FTP library of the [Ballerina language](https://ballerina.io/). The library reads and writes files on a remote FTP, FTPS, or SFTP server, and watches a directory on one for files arriving and leaving.
 
-The FTP library specification has evolved and may continue to evolve in the future. The released versions of the specification can be found under the relevant GitHub tag.
+This specification may change in future versions. Released versions can be found under the matching GitHub tag.
 
-If you have any feedback or suggestions about the library, start a discussion via a [GitHub issue](https://github.com/ballerina-platform/ballerina-standard-library/issues) or in the [Discord server](https://discord.gg/ballerinalang). Based on the outcome of the discussion, the specification and implementation can be updated. Community feedback is always welcome. Any accepted proposal, which affects the specification is stored under `/docs/proposals`. Proposals under discussion can be found with the label `type/proposal` on GitHub.
+If you have feedback or suggestions, start a discussion with a [GitHub issue](https://github.com/ballerina-platform/ballerina-library/issues) or in the [Discord server](https://discord.gg/ballerinalang). The specification and the implementation can then be updated together. An accepted proposal that affects the specification is stored under `/docs/proposals`; proposals still under discussion carry the `type/proposal` label on GitHub.
 
-The conforming implementation of the specification is released and included in the distribution. Any deviation from the specification is considered a bug.
+The implementation that matches this specification is released with the distribution. Anything the library does differently from this document is a bug.
 
 ## Contents
 
 1. [Overview](#1-overview)
 2. [Security](#2-security)
    * 2.1 [Authentication](#21-authentication)
-   * 2.2 [Authentication Methods](#22-authentication-methods)
+   * 2.2 [SFTP Authentication Methods](#22-sftp-authentication-methods)
+   * 2.3 [SFTP Host Key Verification](#23-sftp-host-key-verification)
+   * 2.4 [FTPS Transport Security](#24-ftps-transport-security)
+   * 2.5 [The Server Root](#25-the-server-root)
 3. [Client](#3-client)
    * 3.1 [Initializing the Client](#31-initializing-the-client)
-      * 3.1.1 [Insecure Client](#311-insecure-client)
-      * 3.1.2 [Secure Client](#312-secure-client)
-      * 3.1.3 [Secure FTPS Client](#313-secure-ftps-client)
-   * 3.2 [Writing Files](#32-writing-files)
-      * 3.2.1 [Write Operations](#321-write-operations)
-      * 3.2.2 [Streaming Writes](#322-streaming-writes)
-   * 3.3 [Reading Files](#33-reading-files)
-      * 3.3.1 [Read Operations](#331-read-operations)
-      * 3.3.2 [Streaming Reads](#332-streaming-reads)
-      * 3.3.3 [Data Binding](#333-data-binding)
-   * 3.4 [File Management](#34-file-management)
-   * 3.5 [Retry Configuration](#35-retry-configuration)
-   * 3.6 [Circuit Breaker](#36-circuit-breaker)
-      * 3.6.1 [State Machine](#361-state-machine)
-      * 3.6.2 [Configuration](#362-configuration)
-      * 3.6.3 [Failure Categories](#363-failure-categories)
+   * 3.2 [Transport Options](#32-transport-options)
+   * 3.3 [Writing Files](#33-writing-files)
+   * 3.4 [Reading Files](#34-reading-files)
+   * 3.5 [Data Binding](#35-data-binding)
+   * 3.6 [File Management](#36-file-management)
+   * 3.7 [Retry](#37-retry)
+   * 3.8 [Circuit Breaker](#38-circuit-breaker)
 4. [Listener](#4-listener)
    * 4.1 [Initializing the Listener](#41-initializing-the-listener)
-      * 4.1.1 [Insecure Listener](#411-insecure-listener)
-      * 4.1.2 [Secure Listener](#412-secure-listener)
    * 4.2 [Service](#42-service)
-      * 4.2.1 [Service Declaration](#421-service-declaration)
-      * 4.2.2 [Service Configuration Annotation](#422-service-configuration-annotation)
-   * 4.3 [File Change Callbacks](#43-file-change-callbacks)
-      * 4.3.1 [Format-Specific Callbacks](#431-format-specific-callbacks)
-      * 4.3.2 [File Delete Callback](#432-file-delete-callback)
-      * 4.3.3 [Error Callback](#433-error-callback)
-      * 4.3.4 [Generic File Change Callback (Deprecated)](#434-generic-file-change-callback-deprecated)
-   * 4.4 [Post-Processing Actions](#44-post-processing-actions)
+   * 4.3 [Content Handlers](#43-content-handlers)
+   * 4.4 [Handler Selection](#44-handler-selection)
    * 4.5 [File Filtering](#45-file-filtering)
-      * 4.5.1 [File Name Pattern](#451-file-name-pattern)
-      * 4.5.2 [File Age Filter](#452-file-age-filter)
-      * 4.5.3 [File Dependency Conditions](#453-file-dependency-conditions)
-   * 4.6 [Distributed Coordination](#46-distributed-coordination)
+   * 4.6 [Post-Processing Actions](#46-post-processing-actions)
+   * 4.7 [Error Handling](#47-error-handling)
+   * 4.8 [Distributed Coordination](#48-distributed-coordination)
+   * 4.9 [The Event Handler (Deprecated)](#49-the-event-handler-deprecated)
 5. [Caller](#5-caller)
 6. [Errors](#6-errors)
-   * 6.1 [Error Hierarchy](#61-error-hierarchy)
-   * 6.2 [Error Handling](#62-error-handling)
 7. [Observability](#7-observability)
    * 7.1 [Metrics](#71-metrics)
    * 7.2 [Tags](#72-tags)
@@ -70,45 +54,198 @@ The conforming implementation of the specification is released and included in t
 
 ## 1. Overview
 
-FTP (File Transfer Protocol) is a standard network protocol for transferring files between a client and a server. SFTP (SSH File Transfer Protocol) adds a layer of security by encrypting the connection using SSH, protecting data in transit. The Ballerina FTP library supports both protocols.
+The library has three parts.
 
-The library exposes two core components:
+| Part | What it does |
+| --- | --- |
+| `ftp:Client` | Reads, writes, moves, copies, and lists files on a server |
+| `ftp:Listener` | Polls a directory on a server and hands each file that arrives or disappears to a service |
+| `ftp:Caller` | A server connection given to a handler, so it can act on the server while processing a file |
 
-- **Client** — The `ftp:Client` connects to an FTP/SFTP server and performs file operations such as reading, writing, moving, copying, and listing files.
-- **Listener** — The `ftp:Listener` monitors a remote FTP/SFTP directory and invokes service callbacks when files are added or removed.
+One connection speaks one protocol, chosen by the `protocol` field.
+
+```ballerina
+public enum Protocol {
+    FTP = "ftp",
+    FTPS = "ftps",
+    SFTP = "sftp"
+}
+```
+
+`FTP` is plain, unencrypted FTP. `FTPS` is FTP over TLS. `SFTP` is file transfer over SSH. Not every configuration field applies to every protocol; each field says which ones it applies to.
+
+Every path is a `/`-separated path on the server, resolved against the root the server presents at login. [Section 2.5](#25-the-server-root) covers what that root is.
+
+Every client operation is `isolated` and may be called concurrently on one client.
 
 ## 2. Security
 
 ### 2.1 Authentication
 
-Both the `ftp:Client` and `ftp:Listener` support authenticated connections via the `auth` configuration field. Authentication is configured using credentials (username and password), a private key, or both. When both are provided, the preferred authentication method can be specified explicitly using an ordered list. If no preference is given, the server and client negotiate the method.
+The `auth` field of the client and listener configuration says who connects.
 
-The `userDirIsRoot` configuration controls how the server root is interpreted. When set to `true`, the login home directory is treated as `/`, which is the correct setting for chrooted server environments. When `false`, the actual server root is used, which may cause failures on servers that restrict root access.
+```ballerina
+public type AuthConfiguration record {|
+    Credentials credentials?;
+    PrivateKey privateKey?;
+    SecureSocket secureSocket?;
+    PreferredMethod[] preferredMethods = [PUBLICKEY, PASSWORD];
+|};
+```
 
-### 2.2 Authentication Methods
+`credentials` is a username with an optional password. The password is optional because public key authentication needs the username alone.
 
-The following authentication methods are supported for SFTP connections:
+```ballerina
+public type Credentials record {|
+    string username;
+    string password?;
+|};
+```
 
-- **PUBLICKEY** — Authenticates using a private key file, optionally protected by a passphrase.
-- **PASSWORD** — Authenticates using a username and password.
-- **KEYBOARD_INTERACTIVE** — An interactive challenge-response authentication mechanism.
-- **GSSAPI_WITH_MIC** — Enterprise authentication using a GSS-API mechanism (e.g., Kerberos).
+`privateKey` is an SSH key for SFTP. `password` decrypts the key file when the key is encrypted.
 
-When a private key is configured, it is used for public key authentication. When credentials are configured, they are used for password or keyboard-interactive authentication. The `preferredMethods` field controls the order in which authentication methods are tried.
+```ballerina
+public type PrivateKey record {|
+    string path;
+    string password?;
+|};
+```
+
+`secureSocket` configures TLS and applies to FTPS only; see [Section 2.4](#24-ftps-transport-security). Omitting `auth` entirely connects anonymously.
+
+### 2.2 SFTP Authentication Methods
+
+`preferredMethods` lists the SSH authentication methods to attempt, best first.
+
+```ballerina
+public enum PreferredMethod {
+    KEYBOARD_INTERACTIVE,
+    GSSAPI_WITH_MIC,
+    PASSWORD,
+    PUBLICKEY
+}
+```
+
+The default is `[PUBLICKEY, PASSWORD]`, so a key is tried before a password. `PUBLICKEY` uses `privateKey`, `PASSWORD` and `KEYBOARD_INTERACTIVE` use `credentials`, and `GSSAPI_WITH_MIC` uses a GSS-API mechanism such as Kerberos. Listing a method whose configuration is absent leaves that method with nothing to offer, and the server moves on to the next one.
+
+```ballerina
+ftp:Client sftpClient = check new ({
+    protocol: ftp:SFTP,
+    host: "sftp.example.com",
+    port: 22,
+    auth: {
+        credentials: {username: "alice"},
+        privateKey: {path: "/keys/id_rsa", password: "***"},
+        preferredMethods: [ftp:PUBLICKEY]
+    },
+    userDirIsRoot: true
+});
+```
+
+### 2.3 SFTP Host Key Verification
+
+**Host key verification is off unless `sftpSshKnownHosts` names an existing file.** With such a file, strict host key checking is enabled against it, and a server whose key is not listed is refused. Without it — the default — the server key is accepted unseen, and a man-in-the-middle is not detected.
+
+```ballerina
+ftp:Client sftpClient = check new ({
+    protocol: ftp:SFTP,
+    host: "sftp.example.com",
+    port: 22,
+    auth: {credentials: {username: "alice", password: "***"}},
+    sftpSshKnownHosts: "~/.ssh/known_hosts"
+});
+```
+
+A `~` at the start of the path is expanded to the home directory of the user running the program. **A path that does not exist is a warning in the log, not an error.** The connection then proceeds with verification off, so a typo in this path silently removes the protection it was added for.
+
+### 2.4 FTPS Transport Security
+
+`secureSocket` controls TLS on an FTPS connection.
+
+```ballerina
+public type SecureSocket record {|
+    crypto:KeyStore key?;
+    string|crypto:TrustStore cert?;
+    FtpsMode mode = EXPLICIT;
+    FtpsDataChannelProtection dataChannelProtection = PRIVATE;
+    boolean verifyHostName = true;
+|};
+```
+
+`key` is a client keystore, and is needed only for mutual TLS. `cert` is what the server certificate chain is validated against — a PEM file path, or a `crypto:TrustStore` for JKS and PKCS12. When `cert` is absent, the JDK's own truststore (`cacerts`) is used, so a certificate from a public CA validates without any configuration.
+
+```ballerina
+public enum FtpsMode {
+    IMPLICIT,
+    EXPLICIT
+}
+```
+
+`EXPLICIT`, the default, connects in plain FTP and upgrades with `AUTH TLS`; the conventional port is 21. `IMPLICIT` negotiates TLS from the first byte; the conventional port is 990.
+
+```ballerina
+public enum FtpsDataChannelProtection {
+    CLEAR,
+    PRIVATE,
+    SAFE,
+    CONFIDENTIAL
+}
+```
+
+`dataChannelProtection` covers the data channel that carries file content, separately from the command channel. `PRIVATE` (the default) and `CONFIDENTIAL` encrypt it, `SAFE` gives integrity only, and **`CLEAR` leaves file content unencrypted on the wire** even though the command channel stays protected.
+
+`verifyHostName` checks the CN or SAN of the server certificate against the host being connected to. It defaults to `true`. Setting it to `false` accepts a certificate belonging to a different name, and is for development against a certificate whose identity does not match the host. It does not accept an untrusted certificate: a self-signed or private-CA certificate still has to be trusted through `cert`.
+
+A certificate the truststore does not trust, and a certificate whose identity does not match the host while `verifyHostName` is `true`, both fail at the TLS handshake with an `ftp:Error`.
+
+```ballerina
+ftp:Client ftpsClient = check new ({
+    protocol: ftp:FTPS,
+    host: "ftps.example.com",
+    port: 21,
+    auth: {
+        credentials: {username: "alice", password: "***"},
+        secureSocket: {
+            cert: {path: "/certs/truststore.p12", password: "***"},
+            mode: ftp:EXPLICIT
+        }
+    }
+});
+```
+
+### 2.5 The Server Root
+
+`userDirIsRoot` decides what `/` means. When `true`, the login home directory is the root, which is what a chrooted or jailed account needs. When `false` — the default — the actual server root is used, and a server that refuses to change directory above the home directory fails.
 
 ## 3. Client
 
-The `ftp:Client` connects to an FTP or SFTP server and provides operations for reading, writing, and managing files. All client operations are isolated and can be called concurrently.
-
 ### 3.1 Initializing the Client
 
-The `ftp:Client` is initialized with a `ClientConfiguration` record that specifies the target server. If initialization fails (for example, due to a connection error), an `ftp:Error` is returned.
+Every field has a default, so a client for a local server on the standard port needs no configuration at all.
 
-#### 3.1.1 Insecure Client
+```ballerina
+public type ClientConfiguration record {|
+    Protocol protocol = FTP;
+    string host = "127.0.0.1";
+    int port = 21;
+    AuthConfiguration auth?;
+    boolean userDirIsRoot = false;
+    boolean laxDataBinding = false;
+    decimal connectTimeout = 30.0;
+    SocketConfig socketConfig?;
+    ProxyConfiguration proxy?;
+    FileTransferMode fileTransferMode = BINARY;
+    TransferCompression[] sftpCompression = [NO];
+    string sftpSshKnownHosts?;
+    FailSafeOptions csvFailSafe?;
+    RetryConfig retryConfig?;
+    CircuitBreakerConfig circuitBreaker?;
+|};
+```
 
-An insecure FTP client is initialized by specifying the `FTP` protocol, along with the host and port of the target server.
+`connectTimeout` is in seconds. `port` defaults to 21, which suits FTP and explicit FTPS; SFTP normally wants 22 and implicit FTPS normally wants 990.
 
-###### Example: Insecure FTP Client
+Creating the client resolves the server root, so an unreachable host, a rejected identity, or an untrusted certificate fails here rather than on the first operation.
 
 ```ballerina
 ftp:Client ftpClient = check new ({
@@ -118,128 +255,117 @@ ftp:Client ftpClient = check new ({
 });
 ```
 
-#### 3.1.2 Secure Client
+`close` releases the connection.
 
-A secure SFTP client is initialized by specifying the `SFTP` protocol and providing authentication details. Both credentials and a private key may be provided simultaneously.
+### 3.2 Transport Options
 
-###### Example: SFTP Client with Credentials
+These fields tune the transport. Each one applies to a subset of the protocols, and is ignored by the others.
 
-```ballerina
-ftp:Client sftpClient = check new ({
-    protocol: ftp:SFTP,
-    host: "sftp.example.com",
-    port: 22,
-    auth: {
-        credentials: {
-            username: "user",
-            password: "pass"
-        }
-    },
-    userDirIsRoot: true
-});
-```
-
-###### Example: SFTP Client with Private Key
+`socketConfig` sets the timeouts that apply once a connection is open. All three are in seconds.
 
 ```ballerina
-ftp:Client sftpClient = check new ({
-    protocol: ftp:SFTP,
-    host: "sftp.example.com",
-    port: 22,
-    auth: {
-        credentials: {username: "user"},
-        privateKey: {
-            path: "/path/to/private.key",
-            password: "keypassphrase"
-        },
-        preferredMethods: [ftp:PUBLICKEY]
-    },
-    userDirIsRoot: true
-});
+public type SocketConfig record {|
+    decimal ftpDataTimeout = 120.0;
+    decimal ftpSocketTimeout = 60.0;
+    decimal sftpSessionTimeout = 300.0;
+|};
 ```
 
-#### 3.1.3 Secure FTPS Client
-
-A secure FTPS client is initialized by specifying the `FTPS` protocol. Authentication details are optional — when `secureSocket` is omitted the client uses the JDK's default system truststore (`cacerts`) for chain validation and verifies the server hostname against the certificate. The optional `secureSocket` record controls SSL/TLS behaviour:
-
-- `key` — Keystore for client-side (mTLS) authentication.
-- `cert` — Truststore for validating the server certificate chain. When omitted, the JDK's default system truststore is used.
-- `mode` — `EXPLICIT` (default; start plain, upgrade via `AUTH TLS`) or `IMPLICIT` (TLS from connect).
-- `dataChannelProtection` — `PRIVATE` (default), `SAFE`, `CONFIDENTIAL`, or `CLEAR`.
-- `verifyHostName` — Whether to verify that the server certificate's CN/SAN matches the host being connected to. Defaults to `true`. Set to `false` only for development or testing when a trusted certificate's identity does not match the host. Self-signed or private-CA certificates must still be trusted via `secureSocket.cert` or the default truststore.
-
-Connection attempts fail at the TLS handshake with an `ftp:Error` when the server certificate is not trusted by the configured truststore (or the JDK default), or when `verifyHostName` is `true` and the certificate identity does not match the connect host.
-
-###### Example: FTPS Client
+`fileTransferMode` applies to FTP. `BINARY`, the default, transfers bytes unchanged. `ASCII` converts line endings, and corrupts anything that is not text.
 
 ```ballerina
-ftp:Client ftpsClient = check new ({
-    protocol: ftp:FTPS,
-    host: "ftps.example.com",
-    port: 21,
-    auth: {
-        credentials: {username: "user", password: "pass"},
-        secureSocket: {
-            cert: {path: "/path/to/truststore.p12", password: "changeit"},
-            mode: ftp:EXPLICIT
-        }
-    }
-});
+public enum FileTransferMode {
+    BINARY,
+    ASCII
+}
 ```
 
-### 3.2 Writing Files
+`sftpCompression` applies to SFTP and lists the compression algorithms to offer, best first. The default offers none.
 
-#### 3.2.1 Write Operations
+```ballerina
+public enum TransferCompression {
+    ZLIB = "zlib",
+    ZLIBOPENSSH = "zlib@openssh.com",
+    NO = "none"
+}
+```
 
-The client provides typed write methods for writing content in different formats to the server. All write methods accept a `FileWriteOption` parameter that controls whether the operation overwrites an existing file (`OVERWRITE`) or appends to it (`APPEND`). The default is `OVERWRITE`.
+`proxy` applies to SFTP and routes the connection through a proxy.
 
-- `putBytes(path, content)` — Writes raw binary content to the specified path.
-- `putText(path, content)` — Writes a UTF-8 encoded string to the specified path.
-- `putJson(path, content)` — Serializes and writes a JSON value or a Ballerina record to the specified path.
-- `putXml(path, content)` — Serializes and writes an XML value or a Ballerina record to the specified path.
-- `putCsv(path, content)` — Serializes and writes tabular data (as a 2D string array or a record array) in CSV format to the specified path.
+```ballerina
+public type ProxyConfiguration record {|
+    string host;
+    int port;
+    ProxyType 'type = HTTP;
+    ProxyCredentials auth?;
+    string command?;
+|};
 
-###### Example: Writing a Text File
+public enum ProxyType {
+    HTTP,
+    SOCKS5,
+    STREAM
+}
+```
+
+`command` belongs to `STREAM`, which reaches the server through a jump host by running a local command such as `ssh -W %h:%p jumphost`. `HTTP` and `SOCKS5` ignore it.
+
+### 3.3 Writing Files
+
+| Method | Content |
+| --- | --- |
+| `putBytes` | `byte[]` |
+| `putText` | `string` |
+| `putJson` | `json`, or a record |
+| `putXml` | `xml`, or a record |
+| `putCsv` | `string[][]` or `record {}[]` |
+| `putBytesAsStream` | `stream<byte[], error?>` |
+| `putCsvAsStream` | `stream<string[]\|record {}, error?>` |
+
+Every one of them takes an `ftp:FileWriteOption`, which defaults to `OVERWRITE`.
+
+```ballerina
+public enum FileWriteOption {
+    OVERWRITE,
+    APPEND
+}
+```
+
+A write creates the file when it is not there. `putText` and `putJson` encode as UTF-8.
+
+`putCsv` writes a header row taken from the record field names when the content is a `record {}[]` and the option is not `APPEND`. Appending a record array writes data rows only, so a file built entirely by appends has no header. A `string[][]` never gets a header row; whatever the first row holds is written as-is.
+
+The streaming writes take a stream instead of a value in memory, which is what a file too large to hold needs.
 
 ```ballerina
 check ftpClient->putText("/uploads/hello.txt", "Hello, World!");
-```
-
-###### Example: Appending to an Existing File
-
-```ballerina
 check ftpClient->putText("/logs/app.log", "New log entry\n", ftp:APPEND);
 ```
-
-#### 3.2.2 Streaming Writes
-
-For large files, the client supports streaming write methods that process data in chunks without loading the entire content into memory.
-
-- `putBytesAsStream(path, content)` — Writes a stream of byte chunks to the specified path.
-- `putCsvAsStream(path, content)` — Writes a stream of CSV rows (each row as a string array or record) to the specified path.
-
-###### Example: Streaming a Large File
 
 ```ballerina
 stream<io:Block, io:Error?> fileStream = check io:fileReadBlocksAsStream("/local/data.bin", 4096);
 check ftpClient->putBytesAsStream("/uploads/data.bin", fileStream);
 ```
 
-### 3.3 Reading Files
+`put` and `append` are the earlier untyped writes. Both are deprecated in favour of the typed methods above.
 
-#### 3.3.1 Read Operations
+### 3.4 Reading Files
 
-The client provides typed read methods for reading files in different formats. These methods retrieve the entire file content into memory and support automatic retry when a retry configuration is provided (see [Section 3.5](#35-retry-configuration)).
+| Method | Returns |
+| --- | --- |
+| `getBytes` | `byte[]` |
+| `getText` | `string` |
+| `getJson` | the `json` or record type expected at the call site |
+| `getXml` | the `xml` or record type expected at the call site |
+| `getCsv` | `string[][]`, or the `record {}[]` type expected at the call site |
+| `getBytesAsStream` | `stream<byte[], error?>` |
+| `getCsvAsStream` | a stream of `string[]`, or of the record type expected at the call site |
 
-- `getBytes(path)` — Reads the file at the specified path as a raw byte array.
-- `getText(path)` — Reads the file at the specified path as a UTF-8 encoded string.
-- `getJson(path)` — Reads and parses the file as JSON, with optional data binding to a target type.
-- `getXml(path)` — Reads and parses the file as XML, with optional data binding to a target type.
-- `getCsv(path)` — Reads and parses a CSV file, with optional data binding to a target type. The first row of the file is treated as the header row.
+Reading a path that is not there gives an `ftp:FileNotFoundError`.
 
-If the file content cannot be parsed or bound to the expected type, a `ContentBindingError` is returned.
+The first five read the whole file into memory, and are the operations `retryConfig` retries; see [Section 3.7](#37-retry). The two streaming reads hold the file open until the stream is consumed or closed, so always close them.
 
-###### Example: Reading a JSON File
+`getCsv` and `getCsvAsStream` treat the first row of the file as the header row.
 
 ```ballerina
 type Order record {|
@@ -247,18 +373,8 @@ type Order record {|
     string item;
 |};
 
-Order order = check ftpClient->getJson("/data/order.json");
+Order 'order = check ftpClient->getJson("/data/order.json");
 ```
-
-#### 3.3.2 Streaming Reads
-
-For large files, the client supports streaming read methods that return data as a stream, allowing processing of individual chunks without loading the full file into memory.
-
-- `get(path)` — Returns a raw byte stream from the remote file. The caller is responsible for closing the stream after use.
-- `getBytesAsStream(path)` — Returns a stream of byte chunks from the remote file.
-- `getCsvAsStream(path)` — Returns a stream of CSV rows, with optional data binding to a target row type.
-
-###### Example: Streaming a Large CSV File
 
 ```ballerina
 stream<Employee, error?> rows = check ftpClient->getCsvAsStream("/reports/employees.csv");
@@ -267,49 +383,110 @@ check rows.forEach(function(Employee emp) {
 });
 ```
 
-#### 3.3.3 Data Binding
+`get` is the earlier untyped read, returning a raw byte stream. It is deprecated in favour of the typed methods above.
 
-The typed read methods (`getJson`, `getXml`, `getCsv`, `getCsvAsStream`) support data binding via the `targetType` parameter. When a target type is provided, the parsed content is automatically bound to the specified Ballerina type. If parsing or binding fails, a `ContentBindingError` is returned.
+### 3.5 Data Binding
 
-The `laxDataBinding` configuration on the client controls whether missing or null fields are permitted when binding structured data. When `true`, missing fields are ignored and null values are accepted. When `false` (the default), strict binding is enforced.
+`getJson`, `getXml`, `getCsv`, and `getCsvAsStream` bind the content to the type expected at the call site. There is no separate conversion step.
 
-### 3.4 File Management
+Content that does not match the target type gives an `ftp:ContentBindingError`, whose detail record carries the path and the raw bytes that failed:
 
-The client provides the following file and directory management operations. All operations return an `ftp:Error` on failure.
+```ballerina
+public type ContentBindingErrorDetail record {|
+    string filePath?;
+    byte[] content?;
+|};
+```
 
-- `mkdir(path)` — Creates a new directory at the specified path on the server.
-- `rmdir(path)` — Deletes an empty directory at the specified path on the server. The operation fails if the directory is not empty.
-- `delete(path)` — Deletes the file at the specified path on the server.
-- `rename(origin, destination)` — Renames a file or moves it to a new location within the same server. The destination path must not already exist.
-- `move(sourcePath, destinationPath)` — Moves a file from one location to another on the server.
-- `copy(sourcePath, destinationPath)` — Creates a copy of a file at a new location on the server.
-- `exists(path)` — Returns `true` if the file or directory at the specified path exists, or `false` otherwise.
-- `size(path)` — Returns the size of the file at the specified path in bytes.
-- `list(path)` — Returns an array of `ftp:FileInfo` records representing the contents of the specified directory.
-- `isDirectory(path)` — Returns `true` if the resource at the specified path is a directory.
+`laxDataBinding` relaxes the match. With it, a JSON or XML null binds to an optional field and an absent field binds to a nilable type; strict binding, the default, rejects both.
 
-###### Example: Listing Files in a Directory
+`csvFailSafe` applies to `getCsv`. A record that cannot be bound is then skipped and recorded, instead of failing the whole read. `contentType` decides what is recorded for each skipped record.
+
+```ballerina
+public type FailSafeOptions record {|
+    ErrorLogContentType contentType = METADATA;
+|};
+
+public enum ErrorLogContentType {
+    METADATA,
+    RAW,
+    RAW_AND_METADATA
+}
+```
+
+Skipped records are appended to `<file-name>_error.log` in the working directory of the Ballerina program, not on the server. Under `RAW` and `RAW_AND_METADATA` that file holds the raw text of the skipped records, and so is as sensitive as the data being read.
+
+`csvFailSafe` does not reach `getCsvAsStream`. A record that cannot be bound in a streaming CSV read fails the stream.
+
+### 3.6 File Management
+
+`list` returns an `ftp:FileInfo` for every entry of a directory.
+
+```ballerina
+public type FileInfo record {|
+    string path;
+    int size;
+    int lastModifiedTimestamp;
+    string name;
+    boolean isFolder;
+    boolean isFile;
+    string pathDecoded;
+    string extension;
+    string publicURIString;
+    string fileType;
+    boolean isAttached;
+    boolean isContentOpen;
+    boolean isExecutable;
+    boolean isHidden;
+    boolean isReadable;
+    boolean isWritable;
+    int depth;
+    string scheme;
+    string uri;
+    string rootURI;
+    string friendlyURI;
+|};
+```
+
+`lastModifiedTimestamp` is UNIX epoch time. `extension` carries no leading dot.
+
+| Method | Behaviour |
+| --- | --- |
+| `mkdir` | Creates a directory, and the directories above it. Fails with `ftp:FileAlreadyExistsError` when the path is taken |
+| `rmdir` | **Removes a directory and everything inside it, recursively.** Fails with `ftp:FileNotFoundError` when the path is absent |
+| `delete` | Removes a file. Fails with `ftp:FileNotFoundError` when the path is absent |
+| `rename` | Moves the file to the destination path |
+| `move` | The same operation as `rename` |
+| `copy` | Duplicates the file at the destination path |
+| `exists` | Reports whether the path is there |
+| `size` | Reports the size of the file in bytes |
+| `isDirectory` | Reports whether the path is a directory. Fails with `ftp:FileNotFoundError` when the path is absent |
+
+`rename` and `move` are one operation under two names, so either one can move a file to another directory. Both, and `copy`, create the directories leading to the destination when they are absent, and all three fail with `ftp:FileAlreadyExistsError` rather than overwriting an existing destination.
 
 ```ballerina
 ftp:FileInfo[] files = check ftpClient->list("/incoming");
 foreach ftp:FileInfo file in files {
-    io:println(file.name + " (" + file.size.toString() + " bytes)");
+    io:println(string `${file.name} (${file.size} bytes)`);
 }
 ```
 
-### 3.5 Retry Configuration
+### 3.7 Retry
 
-The client can be configured to automatically retry failed read operations using exponential backoff. When a retry configuration is provided, the non-streaming read operations (`getBytes`, `getText`, `getJson`, `getXml`, `getCsv`) are automatically retried on transient failures.
+`retryConfig` retries a failed read with exponential backoff. It covers the reads that load the whole file — `getBytes`, `getText`, `getJson`, `getXml`, and `getCsv` — and not the streaming reads, whose transfer happens later, as the stream is consumed.
 
-The retry behavior is controlled by the following parameters:
-- **count** — The maximum number of retry attempts. Defaults to `3`.
-- **interval** — The initial wait interval in seconds before the first retry. Defaults to `1.0`.
-- **backOffFactor** — The multiplier applied to the wait interval after each failed attempt. Defaults to `2.0`.
-- **maxWaitInterval** — The maximum wait interval in seconds between retries, regardless of the backoff calculation. Defaults to `30.0`.
+```ballerina
+public type RetryConfig record {|
+    int count = 3;
+    decimal interval = 1.0;
+    decimal backOffFactor = 2.0;
+    decimal maxWaitInterval = 30.0;
+|};
+```
 
-When all retry attempts are exhausted without success, an `AllRetryAttemptsFailedError` is returned.
+`interval` is the wait before the first retry, in seconds. Each subsequent wait is multiplied by `backOffFactor`, up to `maxWaitInterval`. With the defaults, the waits are 1, 2, and 4 seconds.
 
-###### Example: Client with Retry Configuration
+When every attempt has failed, the operation returns an `ftp:AllRetryAttemptsFailedError` wrapping the last failure. A `CircuitBreakerOpenError` is not retried, since the circuit is open precisely because retrying is pointless.
 
 ```ballerina
 ftp:Client ftpClient = check new ({
@@ -324,30 +501,47 @@ ftp:Client ftpClient = check new ({
 });
 ```
 
-### 3.6 Circuit Breaker
+### 3.8 Circuit Breaker
 
-The circuit breaker pattern prevents cascading failures when the FTP server becomes unavailable. When the ratio of failed operations within a rolling time window exceeds a configured threshold, the circuit trips to the OPEN state and subsequent requests fail immediately with a `CircuitBreakerOpenError`, without attempting to connect to the server.
+`circuitBreaker` stops a client from queueing work against a server that is failing. Failures are counted over a rolling window, and once the ratio of failures crosses `failureThreshold`, the circuit opens and every operation returns an `ftp:CircuitBreakerOpenError` at once, without touching the server. It covers every client operation, not only reads.
 
-#### 3.6.1 State Machine
+The circuit has three states.
 
-The circuit breaker operates in three states:
+| State | Behaviour |
+| --- | --- |
+| `CLOSED` | Operations proceed, and outcomes are counted in the rolling window |
+| `OPEN` | Operations fail at once with `ftp:CircuitBreakerOpenError`. No connection is attempted |
+| `HALF_OPEN` | Reached after `resetTime` in `OPEN`. One trial operation is allowed: success closes the circuit, failure opens it again |
 
-- **CLOSED** — Normal operating state. All requests proceed normally, and failures are tracked within the rolling window.
-- **OPEN** — The failure threshold has been exceeded. All requests are rejected immediately with a `CircuitBreakerOpenError`. No connections to the server are attempted.
-- **HALF_OPEN** — After the configured reset time elapses, the circuit transitions to HALF_OPEN. A single trial request is allowed. If it succeeds, the circuit returns to CLOSED. If it fails, the circuit returns to OPEN.
+```ballerina
+public type CircuitBreakerConfig record {|
+    RollingWindow rollingWindow = {};
+    float failureThreshold = 0.5;
+    decimal resetTime = 30;
+    FailureCategory[] failureCategories = [CONNECTION_ERROR, TRANSIENT_ERROR];
+|};
 
-#### 3.6.2 Configuration
+public type RollingWindow record {|
+    int requestVolumeThreshold = 10;
+    decimal timeWindow = 60;
+    decimal bucketSize = 10;
+|};
+```
 
-The circuit breaker is configured using a rolling window that tracks failures over a sliding time period. The following parameters control the behavior:
+`failureThreshold` is a ratio between `0.0` and `1.0`. `resetTime`, `timeWindow`, and `bucketSize` are in seconds, and `bucketSize` must be smaller than `timeWindow`. **The circuit does not open until `requestVolumeThreshold` operations have happened inside the window**, so a threshold crossed by two failures out of two does nothing on its own.
 
-- **failureThreshold** — The ratio of failures to total requests (between `0.0` and `1.0`) that trips the circuit. Defaults to `0.5`.
-- **resetTime** — The number of seconds to wait in the OPEN state before transitioning to HALF_OPEN. Defaults to `30`.
-- **rollingWindow.requestVolumeThreshold** — The minimum number of requests that must occur within the time window before the circuit can trip. Defaults to `10`.
-- **rollingWindow.timeWindow** — The duration of the rolling window in seconds for tracking failures. Defaults to `60`.
-- **rollingWindow.bucketSize** — The size of each time bucket within the rolling window in seconds. Defaults to `10`.
-- **failureCategories** — The categories of errors that count as failures towards tripping the circuit. Defaults to `[CONNECTION_ERROR, TRANSIENT_ERROR]`.
+`failureCategories` decides which failures count towards the ratio. Anything outside the listed categories is returned to the caller without moving the circuit.
 
-###### Example: Client with Circuit Breaker
+```ballerina
+public enum FailureCategory {
+    CONNECTION_ERROR,
+    AUTHENTICATION_ERROR,
+    TRANSIENT_ERROR,
+    ALL_ERRORS
+}
+```
+
+`CONNECTION_ERROR` covers timeouts, refusals, resets, and DNS failures. `AUTHENTICATION_ERROR` covers a rejected identity. `TRANSIENT_ERROR` covers the FTP replies that mean try again — 421, 425, 426, 450, 451, and 452. `ALL_ERRORS` counts everything, a missing file included, so a client that reads paths which may not exist should not use it.
 
 ```ballerina
 ftp:Client ftpClient = check new ({
@@ -366,110 +560,82 @@ ftp:Client ftpClient = check new ({
 });
 ```
 
-#### 3.6.3 Failure Categories
-
-The `failureCategories` field specifies which error types count as failures when evaluating the circuit breaker threshold:
-
-- **CONNECTION_ERROR** — Network failures, connection timeouts, and unreachable hosts.
-- **AUTHENTICATION_ERROR** — Invalid credentials or authorization failures.
-- **TRANSIENT_ERROR** — Server disconnection or temporary unavailability during an operation.
-- **ALL_ERRORS** — Every error type counts as a failure.
-
 ## 4. Listener
-
-The `ftp:Listener` polls a remote FTP or SFTP directory at a configured interval and detects file changes. When files are added or removed, the listener dispatches events to the attached services by invoking their callback methods.
 
 ### 4.1 Initializing the Listener
 
-The `ftp:Listener` is initialized with a `ListenerConfiguration` record that specifies the target server and polling behavior. The `pollingInterval` field controls how frequently (in seconds) the server is checked for changes. The default polling interval is 60 seconds.
-
-#### 4.1.1 Insecure Listener
-
-An insecure FTP listener is initialized by specifying the host and port. The monitored directory path is configured via the `@ftp:ServiceConfig` annotation on the attached service.
-
-###### Example: Insecure FTP Listener
+The listener configuration is the client configuration plus polling, coordination, and the deprecated monitoring fields.
 
 ```ballerina
-listener ftp:Listener ftpListener = check new ({
-    protocol: ftp:FTP,
-    host: "ftp.example.com",
-    port: 21,
-    pollingInterval: 30
-});
+public type ListenerConfiguration record {|
+    Protocol protocol = FTP;
+    string host = "127.0.0.1";
+    int port = 21;
+    AuthConfiguration auth?;
+    @deprecated
+    string path = "/";
+    @deprecated
+    string fileNamePattern?;
+    decimal pollingInterval = 60;
+    boolean userDirIsRoot = false;
+    @deprecated
+    FileAgeFilter fileAgeFilter?;
+    @deprecated
+    FileDependencyCondition[] fileDependencyConditions = [];
+    boolean laxDataBinding = false;
+    decimal connectTimeout = 30.0;
+    SocketConfig socketConfig?;
+    ProxyConfiguration proxy?;
+    FileTransferMode fileTransferMode = BINARY;
+    TransferCompression[] sftpCompression = [NO];
+    string sftpSshKnownHosts?;
+    FailSafeOptions csvFailSafe?;
+    CoordinationConfig coordination?;
+    RetryConfig retryConfig?;
+|};
 ```
 
-#### 4.1.2 Secure Listener
+`pollingInterval` is the number of seconds between polls. On each cycle the listener polls the watched directory of every attached service, and compares what it finds with the previous cycle: a path that has appeared is a new file, and a path that has gone is a deleted file.
 
-A secure SFTP listener is initialized in the same way as a secure client, by specifying the `SFTP` protocol and providing authentication details.
+The four monitoring fields — `path`, `fileNamePattern`, `fileAgeFilter`, and `fileDependencyConditions` — are deprecated at this level. They belong on `@ftp:ServiceConfig`, which is what [Section 4.2](#42-service) covers.
 
-###### Example: SFTP Listener
+`retryConfig` here retries the read the listener does to get file content before binding it, on the same terms as on the client.
 
 ```ballerina
 listener ftp:Listener ftpListener = check new ({
     protocol: ftp:SFTP,
     host: "sftp.example.com",
     port: 22,
-    auth: {
-        credentials: {
-            username: "user",
-            password: "pass"
-        },
-        privateKey: {
-            path: "/path/to/private.key",
-            password: "keypassphrase"
-        }
-    },
-    pollingInterval: 60,
+    auth: {credentials: {username: "alice", password: "***"}},
+    pollingInterval: 30,
     userDirIsRoot: true
 });
 ```
 
+`start`, `attach`, `detach`, `gracefulStop`, and `immediateStop` return a plain `error?`. Configuration the listener can only check once services are attached — a duplicate path, a bad regular expression, an inconsistent age filter — fails at `start`, with an `ftp:InvalidConfigError`.
+
 ### 4.2 Service
 
-#### 4.2.1 Service Declaration
-
-A service is attached to an `ftp:Listener` to receive file change notifications. Services may be declared statically at module level or attached dynamically using the listener's `attach()` method.
-
-###### Example: Static Service Declaration
+A service attached to a listener watches one directory. `@ftp:ServiceConfig` names it and says which of its files matter.
 
 ```ballerina
-service ftp:Service on ftpListener {
-    remote function onFileChange(ftp:WatchEvent & readonly event, ftp:Caller caller) returns error? {
-        foreach ftp:FileInfo addedFile in event.addedFiles {
-            io:println("File added: " + addedFile.path);
-        }
-    }
-}
+public type ServiceConfiguration record {|
+    string path;
+    string fileNamePattern?;
+    FileAgeFilter fileAgeFilter?;
+    FileDependencyCondition[] fileDependencyConditions = [];
+|};
 ```
 
-#### 4.2.2 Service Configuration Annotation
-
-The `@ftp:ServiceConfig` annotation configures the monitoring path and file filtering options at the service level. This allows multiple services attached to a single listener to monitor different directories independently.
-
-The `path` field is mandatory and must be an absolute path starting with `/`. The `fileNamePattern` field accepts a regular expression to filter which files trigger events.
-
-If any service attached to a listener uses `@ftp:ServiceConfig`, then all services attached to that listener must use it. Mixing annotated and unannotated services on the same listener results in an `InvalidConfigError`.
-
-When `@ftp:ServiceConfig` is used, any monitoring-related fields set at the listener level (`path`, `fileNamePattern`, `fileAgeFilter`, `fileDependencyConditions`) are ignored and a deprecation warning is logged.
-
-###### Example: Multiple Services on One Listener
+`path` is required, and is taken as a path from the server root; a leading `/` is added when it is missing. Several services may attach to one listener, each watching a different directory. **Two services on one listener may not watch the same path**, and the second one fails with an `ftp:InvalidConfigError`.
 
 ```ballerina
-listener ftp:Listener ftpListener = check new ({
-    protocol: ftp:SFTP,
-    host: "sftp.example.com",
-    port: 22,
-    auth: {credentials: {username: "user", password: "pass"}},
-    pollingInterval: 30
-});
-
 @ftp:ServiceConfig {
     path: "/incoming/orders",
     fileNamePattern: ".*\\.csv"
 }
 service on ftpListener {
     remote function onFileCsv(record {}[] content, ftp:FileInfo fileInfo) returns error? {
-        // Processes CSV files from /incoming/orders
     }
 }
 
@@ -479,77 +645,36 @@ service on ftpListener {
 }
 service on ftpListener {
     remote function onFileJson(json content, ftp:FileInfo fileInfo) returns error? {
-        // Processes JSON files from /incoming/configs
     }
 }
 ```
 
-### 4.3 File Change Callbacks
+The annotation is all-or-nothing per listener. **If any service on a listener carries `@ftp:ServiceConfig`, every service on that listener must carry it**, and mixing the two fails with an `ftp:InvalidConfigError`. A listener whose services all go without it falls back to the deprecated `path` and filtering fields of the listener configuration, and watches one directory for all of them. Setting both is not an error: the annotation wins, and a deprecation warning is logged for the listener-level fields.
 
-When the listener detects a file change, it invokes the appropriate callback method on the attached service. The `ftp:Caller` parameter is optional in all callbacks; it may be omitted if FTP operations are not required during processing.
+A service must declare at least one handler. The handler methods of a service, and its `ftp:Caller`, are resolved when the service is attached, not once per file.
 
-The `ftp:FileInfo` record provides metadata about the file, including its path, name, size, last modified timestamp, and whether it is a file or directory.
+### 4.3 Content Handlers
 
-#### 4.3.1 Format-Specific Callbacks
+A service declares one or more content handlers. The listener reads the file, binds the content, and passes it as the **first** parameter. A handler never reads the file itself.
 
-In addition to the generic `onFileChange` callback, the listener supports format-specific callbacks that automatically parse file content and pass it to the handler as a typed value. Files are routed to handlers based on their extension: `.txt` → `onFileText`, `.json` → `onFileJson`, `.xml` → `onFileXml`, `.csv` → `onFileCsv`. Files with any other extension are routed to `onFile`. Extension-based routing can be customized per callback using the `@ftp:FunctionConfig` annotation.
+| Handler | Content parameter |
+| --- | --- |
+| `onFileText` | `string` |
+| `onFileJson` | `json`, or a record type the JSON content binds to |
+| `onFileXml` | `xml`, or a record type |
+| `onFileCsv` | `string[][]`, a record array type, or a stream of either |
+| `onFile` | `byte[]`, or a `stream<byte[], error?>` |
 
-**`onFileText`** — Invoked when a `.txt` file is added. The file content is passed as a UTF-8 string.
+Declaring a stream as the content parameter of `onFileCsv` or `onFile` streams the file instead of holding it in memory.
 
-###### Example: Text File Handler
+After the content parameter, a handler may declare an `ftp:FileInfo` parameter, then an `ftp:Caller` parameter. Both are optional, but **the order is fixed**: `ftp:FileInfo` second, `ftp:Caller` third. A handler returns `error?` or `ftp:Error?`.
 
 ```ballerina
-remote function onFileText(string content, ftp:FileInfo fileInfo, ftp:Caller caller) returns error? {
-    io:println("Processing: " + fileInfo.name);
-    io:println(content);
+remote function onFileJson(Config content, ftp:FileInfo fileInfo, ftp:Caller caller) returns error? {
 }
 ```
 
-**`onFileJson`** — Invoked when a `.json` file is added. The content is parsed as JSON and passed as either a `json` value or a data-bound record, depending on the declared parameter type.
-
-###### Example: JSON File Handler with Data Binding
-
-```ballerina
-type Config record {|
-    string env;
-    int maxRetries;
-|};
-
-remote function onFileJson(Config content, ftp:FileInfo fileInfo) returns error? {
-    io:println("Environment: " + content.env);
-}
-```
-
-**`onFileXml`** — Invoked when a `.xml` file is added. The content is parsed as XML and passed as either an `xml` value or a data-bound record.
-
-**`onFileCsv`** — Invoked when a `.csv` file is added. The first row of the CSV file is treated as the header row. The following parameter types are supported:
-- `string[][]` — All rows loaded into memory as arrays of strings.
-- `record {}[]` — All rows loaded into memory and data-bound to the record type.
-- `stream<string[], error>` — Rows processed one at a time as string arrays (memory-efficient for large files).
-- `stream<record {}, error>` — Rows processed one at a time and data-bound to the record type.
-
-###### Example: CSV File Handler with Streaming
-
-```ballerina
-type Employee record {|
-    string name;
-    string department;
-|};
-
-remote function onFileCsv(stream<Employee, error> content, ftp:FileInfo fileInfo) returns error? {
-    check content.forEach(function(Employee emp) {
-        io:println(emp.name);
-    });
-}
-```
-
-**`onFile`** — Invoked when a file with an unrecognized extension is added. The content is passed as either a `byte[]` (entire file in memory) or a `stream<byte[], error>` (for large files).
-
-#### 4.3.2 File Delete Callback
-
-The `onFileDelete` callback is invoked when a file is removed from the monitored directory. The deleted file's path is passed as a string.
-
-###### Example: File Delete Handler
+`onFileDelete` gets the path of a file that has gone from the watched directory since the previous poll, and may declare an optional `ftp:Caller` second parameter.
 
 ```ballerina
 remote function onFileDelete(string deletedFile, ftp:Caller caller) returns error? {
@@ -557,127 +682,75 @@ remote function onFileDelete(string deletedFile, ftp:Caller caller) returns erro
 }
 ```
 
-#### 4.3.3 Error Callback
+`onFileDeleted` is its predecessor, taking a `string[]` of paths rather than one path. It is deprecated in favour of `onFileDelete`, and declaring both is a compile error.
 
-The `onError` callback is invoked when a content binding error occurs while parsing a file. This provides a centralized location for handling files that cannot be parsed into the expected format.
+A file with no handler for it is left alone, and the poll that found it logs a warning.
 
-The callback receives an `ftp:Error` value. When the error is a `ContentBindingError`, its detail record contains the `filePath` of the file that failed and the raw `content` as a byte array.
+### 4.4 Handler Selection
 
-If `onError` is not defined, binding errors are logged and the affected file is skipped.
+A file is routed by a pattern on a handler first, and by its extension second.
 
-###### Example: Error Handler
+A handler that carries `fileNamePattern` on `@ftp:FunctionConfig` claims every file whose whole name matches that regular expression, whatever the extension says. **When two handlers carry patterns that both match a file, which one gets it is not defined**, so patterns on one service should not overlap.
 
-```ballerina
-remote function onError(ftp:Error err, ftp:Caller caller) returns error? {
-    if err is ftp:ContentBindingError {
-        string? filePath = err.detail().filePath;
-        log:printError("Binding failed for file: " + (filePath ?: "unknown"), err);
-        if filePath is string {
-            check caller->move(filePath, "/error/" + filePath);
-        }
-    }
-}
-```
+Otherwise the extension decides, case-insensitively.
 
-#### 4.3.4 Generic File Change Callback (Deprecated)
+| Extension | Handler |
+| --- | --- |
+| `txt`, `log`, `md` | `onFileText` |
+| `json` | `onFileJson` |
+| `xml` | `onFileXml` |
+| `csv` | `onFileCsv` |
+| any other, or none | `onFile` |
 
-The `onFileChange` callback is the general-purpose handler for file system events. It receives a `ftp:WatchEvent` record containing two fields:
-- `addedFiles` — An array of `ftp:FileInfo` records for newly detected files.
-- `deletedFiles` — An array of strings containing the paths of deleted files.
-
-###### Example: Generic File Change Handler
-
-```ballerina
-remote function onFileChange(ftp:WatchEvent & readonly event, ftp:Caller caller) returns error? {
-    foreach ftp:FileInfo file in event.addedFiles {
-        io:println("New file: " + file.path);
-    }
-    foreach string path in event.deletedFiles {
-        io:println("Deleted: " + path);
-    }
-}
-```
-
-### 4.4 Post-Processing Actions
-
-The `@ftp:FunctionConfig` annotation supports automatic file actions after a callback completes. This eliminates the need for boilerplate file management at the end of each handler.
-
-The annotation supports the following actions via the `afterProcess` and `afterError` fields:
-
-- **`DELETE`** — The file is deleted after the handler returns.
-- **`MOVE`** — The file is moved to a specified destination directory after the handler returns. The `moveTo` field specifies the destination path. The `preserveSubDirs` flag (default `true`) controls whether the subdirectory structure relative to the monitored path is preserved in the destination.
-
-`afterProcess` is executed when the handler returns successfully. `afterError` is executed when the handler returns an error or panics. If neither is specified, no post-processing action is taken.
-
-When using `MOVE` with `preserveSubDirs: true`, the destination directory structure must already exist on the server. For example, if monitoring `/input/` and a file at `/input/orders/2024/file.csv` is processed with `moveTo: "/archive/"`, the file is moved to `/archive/orders/2024/file.csv`.
-
-###### Example: Delete After Processing
-
-```ballerina
-service on ftpListener {
-    @ftp:FunctionConfig {
-        afterProcess: ftp:DELETE
-    }
-    remote function onFileJson(json content, ftp:FileInfo fileInfo) returns error? {
-        processJson(content);
-    }
-}
-```
-
-###### Example: Move to Archive on Success, Move to Error Directory on Failure
-
-```ballerina
-service on ftpListener {
-    @ftp:FunctionConfig {
-        afterProcess: {moveTo: "/archive/success/"},
-        afterError: {moveTo: "/archive/failed/"}
-    }
-    remote function onFileXml(xml content, ftp:FileInfo fileInfo) returns error? {
-        check processXml(content);
-    }
-}
-```
-
-###### Example: Routing by File Pattern
-
-The `fileNamePattern` field on `@ftp:FunctionConfig` overrides the extension-based routing for that specific callback, allowing fine-grained control over which files trigger which handler.
-
-```ballerina
-service on ftpListener {
-    @ftp:FunctionConfig {
-        fileNamePattern: "order_.*\\.csv",
-        afterProcess: {moveTo: "/processed/"}
-    }
-    remote function onFileCsv(Employee[] content, ftp:FileInfo fileInfo) returns error? {
-        saveEmployees(content);
-    }
-}
-```
+When the handler for an extension is not declared, the file goes to `onFile`. A file reaches at most one handler.
 
 ### 4.5 File Filtering
 
-#### 4.5.1 File Name Pattern
+Filtering decides which files the listener picks up at all, and is separate from the routing of [Section 4.4](#44-handler-selection). A file the filters reject reaches no handler.
 
-The `fileNamePattern` field in `@ftp:ServiceConfig` accepts a Java regular expression. Only files whose names match the pattern trigger events. If no pattern is specified, all files in the monitored directory trigger events.
+`fileNamePattern` on `@ftp:ServiceConfig` is a Java regular expression matched against the whole file name. Only files that match are picked up. Without it, every file in the directory is picked up. A `fileNamePattern` on a handler narrows this no further; the service-level pattern has already decided what the poll sees.
 
-#### 4.5.2 File Age Filter
+`fileAgeFilter` skips files by age.
 
-The `fileAgeFilter` in `@ftp:ServiceConfig` filters files based on their age. `minAge` (in seconds) skips files younger than the threshold — useful for ignoring files still being written by an upstream process. `maxAge` (in seconds) skips files older than the threshold. Either bound may be set independently; both are optional.
+```ballerina
+public type FileAgeFilter record {|
+    decimal minAge?;
+    decimal maxAge?;
+    AgeCalculationMode ageCalculationMode = LAST_MODIFIED;
+|};
 
-Both values are validated when the listener starts. The listener fails with an `InvalidConfigError` if `minAge` or `maxAge` is negative, or if `minAge` exceeds `maxAge`.
+public enum AgeCalculationMode {
+    LAST_MODIFIED,
+    CREATION_TIME
+}
+```
 
-#### 4.5.3 File Dependency Conditions
+Both bounds are in seconds and inclusive, and either may be set alone. `minAge` is what keeps a file still being written by an upstream process from being picked up half-finished. `ageCalculationMode` chooses the timestamp the age is measured from; `CREATION_TIME` needs a server that reports one. A negative bound, or a `minAge` above `maxAge`, fails at listener start with an `ftp:InvalidConfigError`.
 
-The `fileDependencyConditions` field in `@ftp:ServiceConfig` allows conditional file processing based on the presence of related files. A dependency condition specifies a target file pattern and a list of required companion files that must also be present before the target file triggers an event.
+`fileDependencyConditions` holds a file back until the files it belongs with have arrived too.
 
-The `matchingMode` field controls whether `ALL` required files or `ANY` of them must be present. Capture groups in the target pattern can be referenced in the required file patterns using `$1`, `$2`, etc.
+```ballerina
+public type FileDependencyCondition record {|
+    string targetPattern;
+    string[] requiredFiles;
+    DependencyMatchingMode matchingMode = ALL;
+    int requiredFileCount = 1;
+|};
 
-###### Example: Process a CSV Only When a Marker File Exists
+public enum DependencyMatchingMode {
+    ALL,
+    ANY,
+    EXACT_COUNT
+}
+```
+
+A file whose name matches `targetPattern` is picked up only once `requiredFiles` are present. `ALL` needs every required pattern matched, `ANY` needs one, and `EXACT_COUNT` needs exactly `requiredFileCount` of them. A capture group of `targetPattern` may be referenced in a required pattern as `$1`, `$2`, and so on, which is what ties a data file to its own marker rather than to any marker.
 
 ```ballerina
 @ftp:ServiceConfig {
     path: "/incoming/orders",
     fileNamePattern: "order_.*\\.csv",
+    fileAgeFilter: {minAge: 30},
     fileDependencyConditions: [
         {
             targetPattern: "order_(\\d+)\\.csv",
@@ -687,34 +760,133 @@ The `matchingMode` field controls whether `ALL` required files or `ANY` of them 
     ]
 }
 service on ftpListener {
-    remote function onFileCsv(record {}[] content, ftp:FileInfo fileInfo, ftp:Caller caller) returns error? {
-        check caller->move(fileInfo.path, "/processed/" + fileInfo.name);
+    remote function onFileCsv(record {}[] content, ftp:FileInfo fileInfo) returns error? {
     }
 }
 ```
 
-### 4.6 Distributed Coordination
+### 4.6 Post-Processing Actions
 
-The FTP listener supports distributed coordination for high-availability deployments. When multiple listener instances are deployed across nodes, coordination ensures that only one instance actively polls the FTP server at any time, while the others act as warm standby nodes. This prevents duplicate file processing and provides automatic failover.
+`@ftp:FunctionConfig` says what becomes of the file once the handler has run.
 
-Coordination is enabled by providing a `CoordinationConfig` in the `ListenerConfiguration`. All instances in a coordination group must be configured with the same `coordinationGroup` name and a unique `memberId` per node. Coordination state is managed through a shared database (MySQL or PostgreSQL).
+```ballerina
+public type FtpFunctionConfig record {|
+    string fileNamePattern?;
+    MOVE|DELETE afterProcess?;
+    MOVE|DELETE afterError?;
+|};
+```
 
-The coordination mechanism works as follows:
+`afterProcess` applies when the handler returns successfully, and `afterError` when it returns an error or panics. A file whose applicable action is not set stays where it is, and is picked up again on the next poll. At most one action applies to a file.
 
-1. Members in the same `coordinationGroup` elect an active member through the shared database.
-2. The active member updates a heartbeat record at the configured `heartbeatFrequency` interval (default: 1 second).
-3. Standby members monitor the active member's heartbeat every `livenessCheckInterval` seconds (default: 30 seconds).
-4. If the heartbeat becomes stale, a standby member elects itself as the new active member and begins polling.
-5. Only the active member's polling cycle executes; standby members skip polling silently.
+```ballerina
+public const DELETE = "DELETE";
 
-###### Example: Listener with Distributed Coordination
+public type Move record {|
+    string moveTo;
+    boolean preserveSubDirs = true;
+|};
+
+public type MOVE Move;
+```
+
+`DELETE` is a constant, and removes the file. `MOVE` is an alias for the `Move` record, and relocates the file under `moveTo`, creating the directories leading to the destination when they are absent. `preserveSubDirs`, on by default, recreates the file's subdirectory structure relative to the watched directory under the destination — watching `/input` and processing `/input/orders/2026/file.csv` with `moveTo: "/archive"` puts it at `/archive/orders/2026/file.csv`. With `preserveSubDirs: false` it lands directly in `moveTo`, which collapses two same-named files from different subdirectories onto one destination path. An empty `moveTo` fails at listener start with an `ftp:InvalidConfigError`.
+
+```ballerina
+service on ftpListener {
+    @ftp:FunctionConfig {
+        afterProcess: {moveTo: "/archive/success"},
+        afterError: {moveTo: "/archive/failed"}
+    }
+    remote function onFileXml(xml content, ftp:FileInfo fileInfo) returns error? {
+        check processXml(content);
+    }
+
+    @ftp:FunctionConfig {
+        afterProcess: ftp:DELETE
+    }
+    remote function onFileJson(json content, ftp:FileInfo fileInfo) returns error? {
+        processJson(content);
+    }
+}
+```
+
+A post-processing action runs on the service's `ftp:Caller`, so a service that declares one gets a caller connection whether or not any handler asks for it. **A failing action is logged, and reaches neither the handler nor `onError`**, so a file whose move fails stays in the watched directory and is processed again on the next poll.
+
+A handler that moves or deletes the file itself and also declares `afterProcess` leaves the listener acting on a path that is no longer there.
+
+### 4.7 Error Handling
+
+`onError` is called when file content cannot be bound to the handler's content parameter. It takes the error first — as `ftp:Error` or `error` — and an optional `ftp:Caller` second.
+
+```ballerina
+remote function onError(ftp:Error err, ftp:Caller caller) returns error? {
+    if err is ftp:ContentBindingError {
+        string? filePath = err.detail().filePath;
+        log:printError("Binding failed", err);
+        if filePath is string {
+            check caller->move(filePath, "/error/" + filePath);
+        }
+    }
+}
+```
+
+The error is an `ftp:ContentBindingError`, whose detail record carries the `filePath` and the raw `content` as bytes, so a handler can quarantine or inspect the file that failed.
+
+**`onError` is not a general error handler.** An error the handler itself returns does not reach it — that is what `afterError` is for. Nor does a failure to read the file, a failure in a post-processing action, or a failed poll; those are logged.
+
+Which post-processing action follows a binding failure depends on whether `onError` is declared.
+
+| `onError` | What runs after the failure |
+| --- | --- |
+| Not declared | The error is logged, and the **content handler's** `afterError` runs |
+| Declared | `onError` runs, and then the action on **`onError`'s own** `@ftp:FunctionConfig` — `afterProcess` when `onError` succeeded, `afterError` when it failed |
+
+So declaring `onError` takes the content handler's `afterError` out of the binding-failure path. A service that wants the file quarantined either way puts the action on `onError` too, or moves the file from inside `onError`.
+
+```ballerina
+service on ftpListener {
+    @ftp:FunctionConfig {
+        afterProcess: {moveTo: "/archive"},
+        afterError: {moveTo: "/failed"}
+    }
+    remote function onFileCsv(record {}[] content) returns error? {
+    }
+
+    // Without this, a malformed CSV would go to /failed. With it, /malformed.
+    @ftp:FunctionConfig {
+        afterProcess: {moveTo: "/malformed"}
+    }
+    remote function onError(ftp:Error err) returns error? {
+        log:printError("Binding failed", err);
+    }
+}
+```
+
+### 4.8 Distributed Coordination
+
+`coordination` lets several listener instances share one watched directory without processing the same file twice. Members of a group elect one active member through a shared database; the active member polls, and the rest wait.
+
+```ballerina
+public type CoordinationConfig record {|
+    task:DatabaseConfig databaseConfig = <task:MysqlConfig>{};
+    int livenessCheckInterval = 30;
+    string memberId;
+    string coordinationGroup;
+    int heartbeatFrequency = 1;
+|};
+```
+
+Every member of a group is configured with the same `coordinationGroup` and its own `memberId`. `databaseConfig` is a MySQL or PostgreSQL database, and all members must point at the same one.
+
+The active member writes a heartbeat every `heartbeatFrequency` seconds. Standby members check it every `livenessCheckInterval` seconds, and when it has gone stale, one of them takes over and starts polling. A standby member's polling cycle does nothing at all, so its services see no events until it becomes active. Both intervals are in seconds; `livenessCheckInterval` sets how long a failover takes to notice, and should stay comfortably above `heartbeatFrequency`.
 
 ```ballerina
 listener ftp:Listener ftpListener = check new ({
     protocol: ftp:SFTP,
     host: "sftp.example.com",
     port: 22,
-    auth: {credentials: {username: "user", password: "pass"}},
+    auth: {credentials: {username: "alice", password: "***"}},
     coordination: {
         memberId: "node-1",
         coordinationGroup: "ftp-processors",
@@ -723,22 +895,45 @@ listener ftp:Listener ftpListener = check new ({
         databaseConfig: <task:MysqlConfig>{
             host: "db.example.com",
             user: "dbuser",
-            password: "dbpass",
+            password: "***",
             database: "coordination_db"
         }
     }
 });
 ```
 
+### 4.9 The Event Handler (Deprecated)
+
+`onFileChange` is the original handler, and gets the whole result of a poll rather than one file.
+
+```ballerina
+public type WatchEvent record {|
+    FileInfo[] addedFiles;
+    string[] deletedFiles;
+|};
+```
+
+It takes an `ftp:WatchEvent` or `ftp:WatchEvent & readonly` first, and an optional `ftp:Caller` second. It reads and binds nothing: a service using it fetches content itself, through the caller.
+
+```ballerina
+service ftp:Service on ftpListener {
+    remote function onFileChange(ftp:WatchEvent & readonly event, ftp:Caller caller) returns error? {
+        foreach ftp:FileInfo file in event.addedFiles {
+            io:println("New file: " + file.path);
+        }
+    }
+}
+```
+
+It is deprecated in favour of the content handlers of [Section 4.3](#43-content-handlers), and **cannot be combined with them** — a service declares either `onFileChange` or content handlers, and mixing the two is a compile error. Post-processing actions and `onError` do not apply to it.
+
 ## 5. Caller
 
-The `ftp:Caller` is a facade over an `ftp:Client` that is created internally by the runtime when a service callback declares it as a parameter. It exposes the same operations as `ftp:Client`, allowing service callbacks to perform FTP operations (reading, writing, moving, deleting files) on the same server that the listener is monitoring.
+An `ftp:Caller` declared as a handler parameter lets a handler act on the server while processing a file. It cannot be constructed directly.
 
-The `ftp:Caller` inherits its connection type (secure or insecure) from the listener configuration. It cannot be created directly by user code.
+The caller offers the same operations as the client, less `close`: the write, read, and file management methods, including the deprecated `get`, `put`, and `append`. Its read operations bind to the type expected at the call site, exactly as the client's do. It inherits the listener's protocol, identity, and transport settings.
 
-The `caller` parameter is optional in all service callbacks. If FTP operations are not required within a callback, the parameter may be omitted.
-
-###### Example: Using the Caller to Move a Processed File
+A listener creates a caller only when something needs one: a handler that declares an `ftp:Caller` parameter, or a service with post-processing actions. How many callers exist depends on how the services are configured. With `@ftp:ServiceConfig`, each service gets its own caller connection, rooted at that service's watched path. Without it, one caller is created and shared by every service on the listener. Either way a listener that has callers holds one connection for polling plus one per caller.
 
 ```ballerina
 service on ftpListener {
@@ -749,41 +944,41 @@ service on ftpListener {
 }
 ```
 
+The caller belongs to the listener, which closes it when it stops.
+
 ## 6. Errors
 
-### 6.1 Error Hierarchy
+The library defines a hierarchy rooted at `ftp:Error`, so a caller can handle a failure at whatever level of specificity it wants.
 
-The FTP library defines a hierarchy of error types rooted at `ftp:Error`. All FTP-specific errors are distinct subtypes of this base type, enabling both specific and general error handling.
+```ballerina
+public type Error distinct error;
+```
 
-- **`Error`** — The base error type for all FTP-related errors. All other error types are subtypes of this.
-- **`ConnectionError`** — Represents failures when connecting to the server, including network failures, unreachable hosts, and connection refusals.
-- **`FileNotFoundError`** — Represents failures when a requested file or directory does not exist on the server.
-- **`FileAlreadyExistsError`** — Represents failures when attempting to create a file or directory that already exists.
-- **`InvalidConfigError`** — Represents failures due to invalid configuration values, such as an invalid port number, regex pattern, or timeout value.
-- **`ServiceUnavailableError`** — Represents transient server-side failures. Common causes include server overload, connection issues, or temporary file locks. Operations that return this error may succeed on retry.
-- **`ContentBindingError`** — Represents failures when file content cannot be parsed or bound to the expected Ballerina type. This includes JSON/XML parse errors, CSV format errors, and record type binding failures. The error's detail record includes the `filePath` and the raw `content` as bytes.
-- **`AllRetryAttemptsFailedError`** — Represents the failure returned when all retry attempts are exhausted. It wraps the last encountered error.
-- **`CircuitBreakerOpenError`** — A subtype of `ServiceUnavailableError` returned when the circuit breaker is in the OPEN state. It indicates that requests are being blocked to prevent cascading failures.
+| Error | Means |
+| --- | --- |
+| `Error` | The base type. Every error below is a subtype |
+| `ConnectionError` | The server could not be reached — network failure, unreachable host, refused connection |
+| `FileNotFoundError` | The path is not on the server |
+| `FileAlreadyExistsError` | The destination of a `mkdir`, `rename`, `move`, or `copy` is taken |
+| `InvalidConfigError` | A configuration value is unusable — a bad port, regular expression, timeout, path, or filter bound |
+| `ServiceUnavailableError` | A transient server failure that may succeed on retry — overload (421), data connection trouble (425, 426), a temporary lock (450), or a server-side processing failure (451) |
+| `ContentBindingError` | File content could not be parsed or bound to the expected type. Its detail record carries the `filePath` and the raw `content` |
+| `AllRetryAttemptsFailedError` | Every retry attempt failed. It wraps the last failure |
+| `CircuitBreakerOpenError` | A subtype of `ServiceUnavailableError`, returned while the circuit is open |
 
-### 6.2 Error Handling
+Every client and caller operation that can fail returns an `ftp:Error`. The listener lifecycle methods `start`, `attach`, `detach`, `gracefulStop`, and `immediateStop` return a plain `error?`, and also propagate errors raised by the task scheduler the listener polls with.
 
-Because all error types are subtypes of `ftp:Error`, callers can handle errors at any level of specificity. More specific error types should be checked before more general ones.
-
-###### Example: Handling Specific Error Types
+Check the specific types before the general ones — `CircuitBreakerOpenError` before `ServiceUnavailableError`, and both before `Error`.
 
 ```ballerina
 byte[]|ftp:Error result = ftpClient->getBytes("/data/file.txt");
 if result is ftp:CircuitBreakerOpenError {
-    // Circuit is open — server is currently unavailable
     applyFallback();
 } else if result is ftp:FileNotFoundError {
-    // File does not exist
     log:printWarn("File not found");
 } else if result is ftp:ConnectionError {
-    // Network-level failure
     log:printError("Connection failed", result);
 } else if result is ftp:Error {
-    // Any other FTP error
     log:printError("FTP operation failed", result);
 } else {
     processBytes(result);
@@ -792,79 +987,62 @@ if result is ftp:CircuitBreakerOpenError {
 
 ## 7. Observability
 
-The FTP library provides built-in observability support through metrics and distributed tracing. When observability is enabled in the Ballerina runtime, the FTP client and listener automatically report telemetry data without any additional configuration.
+The client and the listener report telemetry when observability is enabled in the runtime. No library configuration is involved.
 
 ### 7.1 Metrics
 
-The following metric is published directly:
+One metric is published directly.
 
-| Metric Name | Type | Description |
-|---|---|---|
-| `ftp_active_connections` | Gauge | Number of active FTP/FTPS/SFTP connections |
+| Metric | Type | What it counts |
+| --- | --- | --- |
+| `ftp_active_connections` | Gauge | Open FTP, FTPS, and SFTP connections |
 
-File operation counts, event counts, and error counts are derived from the Ballerina framework's built-in `requests_total_value` metric by filtering on the tags published on each span.
+The gauge goes up when a client or listener is initialized and down when it is closed. A `close` that throws still decrements it: the connection is treated as closed either way.
 
-The `ftp_active_connections` gauge is incremented when a client or listener is initialized and decremented when it is closed. If an exception occurs during `close()`, the gauge is still decremented — the connection is treated as closed regardless of the close error.
+Operation, event, and error counts are not published as metrics of their own. They are derived from the runtime's `requests_total_value` by filtering on the tags of [Section 7.2](#72-tags), which [Section 7.3](#73-deriving-counts-from-requests_total_value) shows.
 
 ### 7.2 Tags
 
-All metrics and trace spans carry tags that identify the connection and operation:
+| Tag | Values | Where |
+| --- | --- | --- |
+| `context` | `client`, `listener` | Metrics, traces |
+| `action.type` | `operation`, `event` | Metrics, traces |
+| `remote.url` | `host:port` of the server | Metrics, traces |
+| `protocol` | `ftp`, `ftps`, `sftp` | Metrics, traces |
+| `host` | Hostname of the current node | Metrics, traces |
+| `operation.type` | `get`, `put`, `admin` | Metrics, traces, on `action.type=operation` spans |
+| `event.type` | `create`, `delete`, `error` | Metrics, traces, on `action.type=event` spans |
+| `error.type` | The Ballerina error type name | Metrics, traces, on any span whose operation or dispatch failed |
+| `file.path` | Source or target path | Traces only |
+| `destination.path` | Destination path of `rename`, `move`, and `copy` | Traces only |
 
-| Tag | Values | Used In |
-|---|---|---|
-| `context` | `client`, `listener` | Metrics, Traces |
-| `action.type` | `operation`, `event` | Metrics, Traces |
-| `remote.url` | `host:port` of the remote server | Metrics, Traces |
-| `protocol` | `ftp`, `ftps`, `sftp` | Metrics, Traces |
-| `host` | Hostname of the current node | Metrics, Traces |
-| `operation.type` | `get`, `put`, `admin` | Metrics, Traces (on `action.type=operation` spans only) |
-| `event.type` | `create`, `delete`, `error` | Metrics, Traces (on `action.type=event` spans) |
-| `error.type` | `ConnectionError`, `AuthenticationError`, `FileNotFoundError`, `FileAlreadyExistsError`, `ServiceUnavailableError`, `ContentBindingError`, `RetryError`, `CircuitBreakerOpenError`, `InvalidConfigError`, `CloseError` | Metrics, Traces (on `event.type=error` spans) |
-| `file.path` | Source/target file path of the operation | Traces only |
-| `destination.path` | Destination path for two-path operations (`rename`, `move`, `copy`) | Traces only |
+`file.path` and `destination.path` are left off metrics deliberately, to keep label cardinality bounded. They appear on trace spans only.
 
-`file.path` and `destination.path` are intentionally excluded from metrics to avoid unbounded label cardinality. They are captured on trace spans only.
+> **Note:** Prometheus normalizes `.` to `_` in label names, so `action.type` becomes `action_type`. Jaeger and other trace backends keep the dotted names. The PromQL in [Section 7.3](#73-deriving-counts-from-requests_total_value) uses the normalized form.
 
-> **Note:** Prometheus normalizes `.` to `_` in label names (e.g. `action.type` → `action_type`, `operation.type` → `operation_type`). Jaeger and other trace backends preserve the original dotted names. The PromQL examples in §7.3 use the Prometheus-normalized form.
+A client operation span carries `context=client` and `action.type=operation`. `operation.type` says which kind of method ran.
 
-Client operation spans use `context=client` and `action.type=operation`. The `operation.type` tag maps to the client method invoked:
+| `operation.type` | Methods |
+| --- | --- |
+| `get` | `getBytes`, `getText`, `getJson`, `getXml`, `getCsv`, `getBytesAsStream`, `getCsvAsStream` |
+| `put` | `putBytes`, `putText`, `putJson`, `putXml`, `putCsv`, `putBytesAsStream`, `putCsvAsStream` |
+| `admin` | `delete`, `rename`, `move`, `copy`, `mkdir`, `rmdir`, `isDirectory`, `list`, `exists`, `size` |
 
-| `operation.type` | Triggered by |
-|---|---|
-| `get` | `getBytes()`, `getText()`, `getJson()`, `getXml()`, `getCsv()`, `getBytesAsStream()`, `getCsvAsStream()` |
-| `put` | `putBytes()`, `putText()`, `putJson()`, `putXml()`, `putCsv()`, `putBytesAsStream()`, `putCsvAsStream()` |
-| `admin` | `delete()`, `rename()`, `move()`, `copy()`, `mkdir()`, `rmdir()`, `isDirectory()`, `list()`, `exists()`, `size()` |
+A listener event span carries `context=listener` and `action.type=event`. `event.type` says what happened.
 
-For `getBytesAsStream()` and `getCsvAsStream()`, the `error.type` tag is not added to the span when an error occurs inside the async callback because the Ballerina strand is suspended at that point. Operation tags are still applied before the yield.
+| `event.type` | Dispatched to |
+| --- | --- |
+| `create` | A content handler, or `onFileChange` |
+| `delete` | `onFileDelete` |
+| `error` | `onError` |
 
-Listener event spans use `context=listener` and `action.type=event`. The `event.type` tag identifies the event:
+`error.type` is the name of the Ballerina error that failed, one of `Error`, `ConnectionError`, `FileNotFoundError`, `FileAlreadyExistsError`, `InvalidConfigError`, `ServiceUnavailableError`, `ContentBindingError`, `AllRetryAttemptsFailedError`, and `CircuitBreakerOpenError`. On a listener `event.type=error` span it is always `ContentBindingError`, since that is the only failure dispatched to `onError`.
 
-| `event.type` | Triggered by |
-|---|---|
-| `create` | File added or modified; dispatched to format-specific callbacks or `onFileChange` |
-| `delete` | File deleted; dispatched to `onFileDelete` |
-| `error` | Content-binding or deserialization failure; dispatched to `onError` |
-
-Transport-level errors (e.g. polling connection failures) do not generate a span or metric entry. Only errors dispatched to the service's `onError` callback are recorded.
-
-When errors are dispatched to `onError`, the span includes both `event.type=error` and an `error.type` tag set to the Ballerina error type name:
-
-| `error.type` | Ballerina error |
-|---|---|
-| `ConnectionError` | `ftp:ConnectionError` |
-| `AuthenticationError` | `ftp:AuthenticationError` |
-| `FileNotFoundError` | `ftp:FileNotFoundError` |
-| `FileAlreadyExistsError` | `ftp:FileAlreadyExistsError` |
-| `ServiceUnavailableError` | `ftp:ServiceUnavailableError` |
-| `ContentBindingError` | `ftp:ContentBindingError` |
-| `RetryError` | `ftp:RetryError` |
-| `CircuitBreakerOpenError` | `ftp:CircuitBreakerOpenError` |
-| `InvalidConfigError` | `ftp:InvalidConfigError` |
-| `CloseError` | Error while closing a connection |
+Two failures are invisible here. A transport-level failure, such as a poll that could not connect, produces no span or metric entry. And `getBytesAsStream` and `getCsvAsStream` do not get an `error.type` for a failure inside the asynchronous callback, because the Ballerina strand is suspended at that point; the operation tags applied before the yield are still there.
 
 ### 7.3 Deriving Counts from `requests_total_value`
 
-Since the Ballerina runtime automatically publishes `requests_total_value` for each observed span, operation and event counts can be derived using PromQL queries:
+The runtime publishes `requests_total_value` for every observed span, so operation and event counts come from PromQL over its tags.
 
 ```promql
 # Client file operations by type
@@ -873,18 +1051,18 @@ rate(requests_total_value{action_type="operation", operation_type="admin", proto
 # Listener file events by type
 rate(requests_total_value{action_type="event", event_type="create"}[1m])
 
-# Errors by category (dispatched to onError)
+# Errors by category, dispatched to onError
 sum by (error_type) (
   rate(requests_total_value{action_type="event", event_type="error"}[5m])
 )
 
-# All FTP activity on a specific node
+# All FTP activity on one node
 rate(requests_total_value{host="node-1", src_module=~"ballerina/ftp.*"}[1m])
 ```
 
 ### 7.4 Enabling Observability
 
-Observability must be enabled in the Ballerina runtime configuration. Add the following to `Config.toml`:
+Observability is turned on in `Config.toml`, not in the library.
 
 ```toml
 [ballerina.observe]
@@ -894,4 +1072,4 @@ tracingEnabled=true
 tracingProvider="jaeger"
 ```
 
-Refer to the [Ballerina Observability documentation](https://ballerina.io/learn/observe-ballerina-programs/) for details on configuring reporters and exporters.
+See the [Ballerina observability documentation](https://ballerina.io/learn/observe-ballerina-programs/) for configuring reporters and exporters.


### PR DESCRIPTION
## Purpose

Rewrite `docs/spec/spec.md` in the tone of the SMB library specification ([module-ballerina-smb#30](https://github.com/ballerina-platform/module-ballerina-smb/pull/30)), and correct it against the implementation.

### Tone

The SMB specification reads more tightly than this one did, and the two libraries cover enough of the same ground that they should read alike. The changes:

- Record and enum definitions inline, instead of prose bullet lists that named fields without giving their types or defaults.
- Method tables in place of `- method(path, content) — Writes…` lists.
- Unlabelled example blocks, instead of `###### Example: …` headings.
- A flatter section tree — four heading levels down to two — with the sub-sub-sections that held one paragraph each folded into their parent.
- A three-part overview table, and bold callouts on the traps rather than caveats buried mid-paragraph.

### Corrections

The API surface was checked against the source rather than the API documentation. Seven claims were wrong:

| Previous claim | What the implementation does |
|---|---|
| `rmdir` "deletes an empty directory… fails if the directory is not empty" | Deletes with `Selectors.SELECT_ALL` — the directory **and its contents, recursively** |
| `.txt` → `onFileText` | `txt`, `log`, and `md` all map to `onFileText` (`FtpFileExtensionMapper`) |
| With `MOVE`, "the destination directory structure must already exist" | `rename`/`move`/`copy` call `parent.createFolder()`, which recurses, so the whole chain is created |
| `onError` is called "when a content binding error occurs… if not defined, the file is skipped" | If `onError` is absent the **content handler's** `afterError` runs; if present, the action on **`onError`'s own** `@ftp:FunctionConfig` runs and the handler's `afterError` does not |
| `error.type` includes `AuthenticationError`, `RetryError`, `CloseError` | None of those types exist. The set is `FtpUtil.ErrorType`, which includes `AllRetryAttemptsFailedError` instead |
| `@ftp:ServiceConfig.path` "must be an absolute path starting with `/`" | A missing leading `/` is added, not rejected |
| `fileNamePattern` on `@ftp:FunctionConfig` "overrides the extension-based routing" | It overrides routing only. The service-level pattern has already filtered the poll, so a handler pattern cannot widen it |

### Additions

Behaviour the previous revision did not cover:

- `csvFailSafe`, `FailSafeOptions`, `ErrorLogContentType`, and the `<file-name>_error.log` side file written to the program's working directory — including that it does not reach `getCsvAsStream`.
- `socketConfig`, `proxy`, `fileTransferMode`, and `sftpCompression`, each scoped to the protocols it applies to.
- `AgeCalculationMode`, and `EXACT_COUNT` with `requiredFileCount`.
- `onFileDeleted` and its deprecation in favour of `onFileDelete`.
- The fixed handler parameter order — content, then `FileInfo`, then `Caller`.
- `onFileChange` being uncombinable with the content handlers.
- `putCsv` writing a header row from record field names unless the option is `APPEND`, and never for a `string[][]`.
- `get`, `put`, and `append` being deprecated.
- Caller lifecycle: created only when a handler declares one or the service has post-processing actions; one per service under `@ftp:ServiceConfig`, otherwise one shared across the listener.
- The `requestVolumeThreshold` floor, below which the circuit cannot open.
- A failing post-processing action being logged and reaching neither the handler nor `onError`.

### Note for reviewers

§2.3 documents that SFTP host key verification is off by default. Both the client and the listener set JSch's `StrictHostKeyChecking` to `"no"` unconditionally, and it is re-enabled only when `sftpSshKnownHosts` points at a file that **exists** — a path that does not resolve logs a warning and the connection proceeds unverified. This is specified as behaviour here, but it may warrant an issue of its own.

## Checks

- Every table-of-contents anchor resolves to a heading, and every heading is linked from the table of contents.
- Every record and enum definition in the specification was diffed field-by-field against `ballerina/*.bal`; all 33 match exactly.
- `changelog.md` is untouched, as there is no library change. `.github/workflows/update_spec.yml` already exists in this repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Rewrote `docs/spec/spec.md` to align with the library implementation and SMB specification structure.
- Reorganized the specification with inline records, enums, method tables, overview tables, and clearer callouts.
- Corrected documented behavior for file operations, routing, directory handling, errors, retries, listener dispatch, filtering, and post-processing.
- Added documentation for FTP, FTPS, and SFTP configuration, lifecycle behavior, CSV processing, age calculation, coordination, observability, deprecated methods, and public API types.
- Updated the specification date. No library source or changelog files changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->