### PR TITLE
Apply standard observability support

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ftp"
-version = "2.20.2"
+version = "2.20.3"
 authors = ["Ballerina"]
 keywords = ["FTP", "SFTP", "remote file", "file transfer", "client", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-ftp"
@@ -46,8 +46,8 @@ path = "./lib/commons-lang3-3.18.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ftp-native"
-version = "2.20.2"
-path = "../native/build/libs/ftp-native-2.20.2.jar"
+version = "2.20.3"
+path = "../native/build/libs/ftp-native-2.20.3-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ftp"
-version = "2.20.3"
+version = "2.21.0"
 authors = ["Ballerina"]
 keywords = ["FTP", "SFTP", "remote file", "file transfer", "client", "service"]
 repository = "https://github.com/ballerina-platform/module-ballerina-ftp"
@@ -46,8 +46,8 @@ path = "./lib/commons-lang3-3.18.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ftp-native"
-version = "2.20.3"
-path = "../native/build/libs/ftp-native-2.20.3-SNAPSHOT.jar"
+version = "2.21.0"
+path = "../native/build/libs/ftp-native-2.21.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "ftp-compiler-plugin"
 class = "io.ballerina.stdlib.ftp.plugin.FtpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.20.3-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.21.0-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "ftp-compiler-plugin"
 class = "io.ballerina.stdlib.ftp.plugin.FtpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.20.2.jar"
+path = "../compiler-plugin/build/libs/ftp-compiler-plugin-2.20.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -58,7 +58,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.20.2"
+version = "2.20.3"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.csv"},
@@ -76,7 +76,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -58,7 +58,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ftp"
-version = "2.20.3"
+version = "2.21.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -142,7 +142,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Owners_: @shafreenAnfar @dilanSachi @Bhashinee \
 _Reviewers_: @shafreenAnfar @Bhashinee \
 _Created_: 2020/10/28 \
-_Updated_: 2026/05/20 \
+_Updated_: 2026/09/01 \
 _Edition_: Swan Lake
 
 ## Introduction
@@ -64,9 +64,20 @@ The conforming implementation of the specification is released and included in t
    * 6.2 [Error Handling](#62-error-handling)
 7. [Observability](#7-observability)
    * 7.1 [Metrics](#71-metrics)
+      * 7.1.1 [Gauges](#711-gauges)
+      * 7.1.2 [Explicit Counters](#712-explicit-counters)
+      * 7.1.3 [Derived Counters](#713-derived-counters)
    * 7.2 [Tags](#72-tags)
-   * 7.3 [Deriving Counts from `requests_total_value`](#73-deriving-counts-from-requests_total_value)
-   * 7.4 [Enabling Observability](#74-enabling-observability)
+      * 7.2.1 [Identity Tags](#721-identity-tags)
+      * 7.2.2 [Action Tags](#722-action-tags)
+      * 7.2.3 [Outcome Tags](#723-outcome-tags)
+      * 7.2.4 [File-Scoped Tags (Trace-Only)](#724-file-scoped-tags-trace-only)
+      * 7.2.5 [Client Operation Tag Mapping](#725-client-operation-tag-mapping)
+      * 7.2.6 [Listener Event Tag Mapping](#726-listener-event-tag-mapping)
+      * 7.2.7 [File Lifecycle Stages](#727-file-lifecycle-stages)
+   * 7.3 [Tracing Structure](#73-tracing-structure)
+   * 7.4 [Sample PromQL Queries](#74-sample-promql-queries)
+   * 7.5 [Enabling Observability](#75-enabling-observability)
 
 ## 1. Overview
 
@@ -792,52 +803,137 @@ if result is ftp:CircuitBreakerOpenError {
 
 ## 7. Observability
 
-The FTP library provides built-in observability support through metrics and distributed tracing. When observability is enabled in the Ballerina runtime, the FTP client and listener automatically report telemetry data without any additional configuration.
+The FTP library provides built-in observability support through metrics and distributed tracing, following the unified observability specification for Ballerina file integration libraries. When observability is enabled in the Ballerina runtime, the FTP client and listener automatically report telemetry data without any additional configuration.
+
+The observability model is module-agnostic: the FTP module publishes the same metric names and tag keys as other file integration modules (SMB, S3, etc.). Module-specific values appear only in tag values (e.g. `module=ftp`), never in metric names.
 
 ### 7.1 Metrics
 
-The following metric is published directly:
+#### 7.1.1 Gauges
 
 | Metric Name | Type | Description |
 |---|---|---|
-| `ftp_active_connections` | Gauge | Number of active FTP/FTPS/SFTP connections |
+| `ftp_active_connections` | Gauge | Number of active FTP/FTPS/SFTP client and listener objects. Incremented on init, decremented on close. Retained for backward compatibility. |
 
-File operation counts, event counts, and error counts are derived from the Ballerina framework's built-in `requests_total_value` metric by filtering on the tags published on each span.
+#### 7.1.2 Explicit Counters
 
-The `ftp_active_connections` gauge is incremented when a client or listener is initialized and decremented when it is closed. If an exception occurs during `close()`, the gauge is still decremented — the connection is treated as closed regardless of the close error.
+| Metric Name | Type | Description |
+|---|---|---|
+| `file_bytes_transferred_total` | Counter | Total bytes read or written across operations. A sum of bytes, not a count of spans. |
+| `file_events_total` | Counter | Total file lifecycle and poll events. Distinguishable by `action.type` tag: `poll` for poll cycles, `event` for file lifecycle stages. |
+
+`file_bytes_transferred_total` is incremented for all non-streaming client read operations (`getBytes`, `getText`, `getJson`, `getXml`, `getCsv`), all client write operations (`putBytes`, `putText`, `putJson`, `putXml`, `putCsv`), and listener content reads during file processing. Every increment carries an `operation.type` tag (`get` or `put`) so that total bytes read across both client and listener can be queried uniformly via `file_bytes_transferred_total{operation_type="get"}`.
+
+`file_events_total` is a single counter that tracks both poll cycles (`action.type=poll_cycle`) and all four file lifecycle stages (`action.type=file_event`, `file.stage=found|dispatched|handled|cleaned_up`). Each event produces an independent `+1` to the counter with its respective tags. Poll cycles are derived via `file_events_total{action_type="poll_cycle"}`; file stages via `file_events_total{file_stage="..."}`. This ensures everything is queryable from a single metric name.
+
+For stages that go through `callMethod` (handled, cleaned_up), the framework additionally creates auto-instrumented spans that appear in distributed traces (Jaeger). However, `requests_total_value` is the **runtime's** metric — it counts one increment per span, not per file. A single poll that finds 50 files still produces only one span. Therefore, per-file counts must always come from `file_events_total`, not from `requests_total_value`. The only valid use of `requests_total_value` is for **client operations**, where one method call (e.g. `getBytes()`) equals one span equals one increment.
+
+#### 7.1.3 Duration Gauges
+
+| Metric Name | Type | Description |
+|---|---|---|
+| `file_databinding_duration_seconds` | Gauge (distribution) | Time in seconds to fetch and convert file content into the target type (JSON, XML, CSV, text, bytes, stream). Each invocation records a separate observation into a sliding-window distribution. |
+| `file_resource_execution_duration_seconds` | Gauge (distribution) | Time in seconds to execute the user's resource/handler method. Each invocation records a separate observation into the same sliding-window distribution. |
+
+Both duration gauges are configured with a `StatisticConfig` that tracks p50, p75, p90, p95, and p99 percentiles over a 5-minute sliding window. They carry `handler.name`, `outcome`, `protocol`, and `remote.url` tags.
+
+- **`file_databinding_duration_seconds`** covers the full data binding pipeline: resolving the remote file, reading bytes over the network, and converting to the handler's parameter type (e.g. `json`, `xml`, `csv` record). For streaming handlers, this measures stream creation time only — actual data transfer is lazy.
+- **`file_resource_execution_duration_seconds`** covers the actual elapsed time of the handler method invocation. This includes everything inside the user's handler — FTP operations, HTTP calls, database queries, custom logic, etc.
+
+#### 7.1.4 Querying Metrics
+
+The following table shows the recommended PromQL source for each logical metric:
+
+| Logical Metric | Description | PromQL Source |
+|---|---|---|
+| Poll cycles | Poll cycles completed by a listener | `file_events_total{action_type="poll_cycle"}` |
+| Files found | Files discovered during a poll | `file_events_total{file_stage="found"}` |
+| Files dispatched | Files matched to a handler and handed over | `file_events_total{file_stage="dispatched"}` |
+| Files skipped | Files found but matched no handler | `file_events_total{file_stage="found", outcome="skipped"}` |
+| Files handled | Handler invocations completed | `file_events_total{file_stage="handled"}` |
+| Files cleaned up | Post-processing actions completed (move/delete) | `file_events_total{file_stage="cleaned_up"}` |
+| Handler errors | Errors from any code inside handler (FTP, HTTP, DB, etc.) | `file_events_total{file_stage="handled", outcome="failure"}` |
+| Data binding duration | Time to fetch and convert file content | `file_databinding_duration_seconds` |
+| Resource execution duration | Time to execute the handler method | `file_resource_execution_duration_seconds` |
+| Bytes read (client + listener) | Total bytes read across all get operations | `file_bytes_transferred_total{operation_type="get"}` |
+| Bytes written (client) | Total bytes written across all put operations | `file_bytes_transferred_total{operation_type="put"}` |
+| Client operations | Client-initiated file operations (get, put, manage) | `requests_total_value{action_type="client_operation"}` |
 
 ### 7.2 Tags
 
-All metrics and trace spans carry tags that identify the connection and operation:
+All metrics and trace spans carry tags that identify the connection, operation, and lifecycle stage.
 
-| Tag | Values | Used In |
-|---|---|---|
-| `context` | `client`, `listener` | Metrics, Traces |
-| `action.type` | `operation`, `event` | Metrics, Traces |
-| `remote.url` | `host:port` of the remote server | Metrics, Traces |
-| `protocol` | `ftp`, `ftps`, `sftp` | Metrics, Traces |
-| `host` | Hostname of the current node | Metrics, Traces |
-| `operation.type` | `get`, `put`, `admin` | Metrics, Traces (on `action.type=operation` spans only) |
-| `event.type` | `create`, `delete`, `error` | Metrics, Traces (on `action.type=event` spans) |
-| `error.type` | `ConnectionError`, `AuthenticationError`, `FileNotFoundError`, `FileAlreadyExistsError`, `ServiceUnavailableError`, `ContentBindingError`, `RetryError`, `CircuitBreakerOpenError`, `InvalidConfigError`, `CloseError` | Metrics, Traces (on `event.type=error` spans) |
-| `file.path` | Source/target file path of the operation | Traces only |
-| `destination.path` | Destination path for two-path operations (`rename`, `move`, `copy`) | Traces only |
+> **Note:** Prometheus normalizes `.` to `_` in label names (e.g. `action.type` → `action_type`, `file.stage` → `file_stage`). Jaeger and other trace backends preserve the original dotted names. The PromQL examples in this section use the Prometheus-normalized form.
 
-`file.path` and `destination.path` are intentionally excluded from metrics to avoid unbounded label cardinality. They are captured on trace spans only.
+#### 7.2.1 Identity Tags
 
-> **Note:** Prometheus normalizes `.` to `_` in label names (e.g. `action.type` → `action_type`, `operation.type` → `operation_type`). Jaeger and other trace backends preserve the original dotted names. The PromQL examples in §7.3 use the Prometheus-normalized form.
+| Tag | Values | Metrics | Traces | Notes |
+|---|---|---|---|---|
+| `module` | `ftp` | Yes | Yes | Identifies the Ballerina module. Always `ftp` regardless of wire protocol (FTP, FTPS, SFTP). |
+| `protocol` | `ftp`, `ftps`, `sftp` | Yes | Yes | The wire protocol. |
+| `type` | `client`, `listener` | Yes | Yes | Whether this is a client or listener operation. |
+| `remote.url` | `host:port` | Yes | Yes | The server endpoint. Added on every observer context at construction time, from the connection configuration. Does not include the protocol prefix since `protocol` is a separate tag. |
+| `watched.path` | Monitored directory path (e.g. `/uploads`) | Yes | Yes | Present on listener events and poll cycles. Distinguishes services monitoring different paths on the same server. |
+| `host` | Local hostname | Yes | Yes | Hostname of the current instance. |
 
-Client operation spans use `context=client` and `action.type=operation`. The `operation.type` tag maps to the client method invoked:
+#### 7.2.2 Action Tags
+
+These tags capture the sequence of events during a file's journey. They help map out the lifecycle stages, showing exactly how a file moves through the system.
+
+| Tag | Values | Metrics | Traces | Notes |
+|---|---|---|---|---|
+| `action.type` | `poll_cycle`, `file_event`, `client_operation` | Yes | Yes | `poll_cycle` — Added on each poll cycle completion (`file_events_total` counter). One entry per poll, regardless of how many files are found. Only applicable to poll-based modules. `file_event` — Added on listener file lifecycle events (found, dispatched, handled, cleaned_up, skipped). `client_operation` — Added on client API calls. |
+| `file.stage` | `found`, `dispatched`, `handled`, `cleaned_up` | Yes | Yes | Maps to the four-stage file lifecycle. Present on listener event spans and metrics. `found` — Added when a file is first discovered during a poll cycle. Every discovered file gets this, including files that will be skipped as no relevant handler found for that. `dispatched` — Added when the file is matched to a content handler and handed over for processing. `handled` — Added when the handler invocation completes. `cleaned_up` — Added when a post-processing action completes. Only present when `afterProcess` or `afterError` is configured. |
+| `event.type` | `create`, `delete`, `error` | Yes | Yes | Type of listener event. `create` — File was added or modified. Added on handler invocation spans for content-based callbacks. `delete` — File was deleted. Added on `onFileDelete` handler spans. `error` — Content-binding failure. Added on `onError` handler spans. |
+| `operation.type` | `get`, `put`, `manage` | Yes | Yes | Present on client operation spans (`action.type=client_operation`) and on `file_bytes_transferred_total` for both client and listener. `get` — Added on `getBytes()`, `getText()`, `getJson()`, `getXml()`, `getCsv()`, `getBytesAsStream()`, `getCsvAsStream()`. `put` — Added on `putBytes()`, `putText()`, `putJson()`, `putXml()`, `putCsv()`, `putBytesAsStream()`, `putCsvAsStream()`. `manage` — Added on `delete()`, `rename()`, `move()`, `copy()`, `mkdir()`, `rmdir()`, `isDirectory()`, `list()`, `exists()`, `size()`. |
+| `handler.name` | Handler method name (e.g. `onFileJson`, `onFileCsv`) | Yes | Yes | Identifies which handler processed the file. Added on: `file.stage=dispatched` — when the handler is selected. `file.stage=handled` — when the handler completes. `file.stage=cleaned_up` — to link cleanup back to the handler that triggered it. Not present on `file.stage=found` (handler not yet determined) or skipped files. |
+| `cleanup.action` | `move`, `delete` | Yes | Yes | `move` — When the file was moved to a destination directory. `delete` — When the file was deleted. Added on `file.stage=cleaned_up` events only. |
+
+#### 7.2.3 Outcome Tags
+
+| Tag | Values | Metrics | Traces | Notes |
+|---|---|---|---|---|
+| `outcome` | `success`, `failure`, `skipped` | Yes | Yes | Result of an operation. `skipped` indicates a file found but not matched to any handler. |
+| `error.type` | `ConnectionError`, `AuthenticationError`, `FileNotFoundError`, `ContentBindingError`, `CloseError`, `no_handler_matched`, `binding_failed`, `move_failed`, `delete_failed`, etc. | Yes | Yes | Present when `outcome=failure` or `outcome=skipped`. Set to the Ballerina error type name for handler and client errors (which can be **any** error type — not just FTP errors, e.g. `ClientError` from HTTP, `ApplicationError` from DB). For lifecycle failures, predefined values are used: `no_handler_matched`, `binding_failed`, `move_failed`, `delete_failed`. Set to `none` when not applicable. |
+
+#### 7.2.4 Tag Consistency Rule
+
+Every increment of a given metric must carry the **same set of label keys**. Prometheus treats a series with labels `{a, b}` and a series with labels `{a, b, c}` as two different time series, even under the same metric name. If tags are conditionally absent, queries like `sum by (file_stage)` silently drop or double-count rows.
+
+When a tag is not applicable for a given stage, the sentinel value `"none"` is used instead of omitting the tag. For example, `file_events_total` always carries `outcome`, `error.type`, `handler.name`, and `watched.path` on every increment — set to `"none"` when not applicable:
+
+```
+file_events_total{file_stage="found",   outcome="none",    error_type="none",            handler_name="none"}
+file_events_total{file_stage="handled", outcome="success", error_type="none",            handler_name="onFileJson"}
+file_events_total{file_stage="handled", outcome="failure", error_type="ConnectionError", handler_name="onFileJson"}
+```
+
+This rule applies to all explicit counters and gauges published by the library. All modules sharing the observability vocabulary must use the same sentinel value.
+
+#### 7.2.5 File-Scoped Tags (Trace-Only)
+
+| Tag | Values | Metrics | Traces | Notes |
+|---|---|---|---|---|
+| `file.path` | Full path of the file | No | Yes | Excluded from metrics to avoid cardinality explosion. |
+| `destination.path` | Target path for move/rename/copy | No | Yes | Excluded from metrics. |
+| `file.size` | Size in bytes | No | Yes | Exact file size on the trace span. |
+| `file.modified_time` | Last-modified timestamp | No | Yes | Needed for stable file identity. |
+
+#### 7.2.6 Client Operation Tag Mapping
+
+Client operation spans use `type=client` and `action.type=client_operation`. The `operation.type` tag maps to the client method invoked:
 
 | `operation.type` | Triggered by |
 |---|---|
 | `get` | `getBytes()`, `getText()`, `getJson()`, `getXml()`, `getCsv()`, `getBytesAsStream()`, `getCsvAsStream()` |
 | `put` | `putBytes()`, `putText()`, `putJson()`, `putXml()`, `putCsv()`, `putBytesAsStream()`, `putCsvAsStream()` |
-| `admin` | `delete()`, `rename()`, `move()`, `copy()`, `mkdir()`, `rmdir()`, `isDirectory()`, `list()`, `exists()`, `size()` |
+| `manage` | `delete()`, `rename()`, `move()`, `copy()`, `mkdir()`, `rmdir()`, `isDirectory()`, `list()`, `exists()`, `size()` |
 
-For `getBytesAsStream()` and `getCsvAsStream()`, the `error.type` tag is not added to the span when an error occurs inside the async callback because the Ballerina strand is suspended at that point. Operation tags are still applied before the yield.
+Listener content reads also carry `operation.type=get` on the `file_bytes_transferred_total` counter, since the listener fetches file content from the remote server in the same way as client get operations.
 
-Listener event spans use `context=listener` and `action.type=event`. The `event.type` tag identifies the event:
+#### 7.2.7 Listener Event Tag Mapping
+
+Listener event spans use `type=listener` and `action.type=file_event`. The `event.type` tag identifies the event:
 
 | `event.type` | Triggered by |
 |---|---|
@@ -845,44 +941,115 @@ Listener event spans use `context=listener` and `action.type=event`. The `event.
 | `delete` | File deleted; dispatched to `onFileDelete` |
 | `error` | Content-binding or deserialization failure; dispatched to `onError` |
 
-Transport-level errors (e.g. polling connection failures) do not generate a span or metric entry. Only errors dispatched to the service's `onError` callback are recorded.
+#### 7.2.8 File Lifecycle Stages
 
-When errors are dispatched to `onError`, the span includes both `event.type=error` and an `error.type` tag set to the Ballerina error type name:
+The listener tracks files through a four-stage lifecycle. Each stage publishes an independent `file_events_total` counter increment with its respective tags.
 
-| `error.type` | Ballerina error |
-|---|---|
-| `ConnectionError` | `ftp:ConnectionError` |
-| `AuthenticationError` | `ftp:AuthenticationError` |
-| `FileNotFoundError` | `ftp:FileNotFoundError` |
-| `FileAlreadyExistsError` | `ftp:FileAlreadyExistsError` |
-| `ServiceUnavailableError` | `ftp:ServiceUnavailableError` |
-| `ContentBindingError` | `ftp:ContentBindingError` |
-| `RetryError` | `ftp:RetryError` |
-| `CircuitBreakerOpenError` | `ftp:CircuitBreakerOpenError` |
-| `InvalidConfigError` | `ftp:InvalidConfigError` |
-| `CloseError` | Error while closing a connection |
+1. **Found** (`file.stage=found`) — A file is discovered during a poll cycle. Each discovered file produces exactly one `found` increment. If the file matches a handler, `outcome=none`. If no handler matches, `outcome=skipped` and `error.type=no_handler_matched` — the file goes no further in the lifecycle.
+2. **Dispatched** (`file.stage=dispatched`) — The file is matched to a content handler and handed over for processing. The `handler.name` tag identifies the target handler.
+3. **Handled** (`file.stage=handled`) — The handler invocation has completed. Tagged with `outcome=success` or `outcome=failure`. On failure, `error.type` is set to the Ballerina error type name returned by the handler. This captures errors from **any** code inside the handler — not just FTP operations, but also HTTP calls, database queries, custom logic, etc. Any error that causes the handler to return an error (via `check` or explicit `return error(...)`) is captured.
+4. **Cleaned up** (`file.stage=cleaned_up`) — Post-processing (move or delete) has completed. Tagged with `cleanup.action` (move/delete) and `outcome` (success/failure). If the cleanup fails, `error.type` is set to `move_failed` or `delete_failed`.
 
-### 7.3 Deriving Counts from `requests_total_value`
+### 7.3 Observability Outputs per File
 
-Since the Ballerina runtime automatically publishes `requests_total_value` for each observed span, operation and event counts can be derived using PromQL queries:
+For each file processed by the listener, the library produces three types of observability output:
 
-```promql
-# Client file operations by type
-rate(requests_total_value{action_type="operation", operation_type="admin", protocol="sftp"}[1m])
+1. **Explicit counters** (`file_events_total`) — All four lifecycle stages publish here. These are direct `MetricRegistry.counter().increment()` calls. No span is involved. Every stage is queryable from this single metric name.
 
-# Listener file events by type
-rate(requests_total_value{action_type="event", event_type="create"}[1m])
+2. **Per-file parent span** — A library-created span (`BSpan.start("ftp", "file-lifecycle", false)`) that covers the entire file lifecycle from discovery to cleanup. The `file.path` tag on this span enables searching for a specific file in Jaeger. The `handled` and `cleaned_up` child spans are automatically parented to it via the `ObserverContext.setParent()` mechanism.
 
-# Errors by category (dispatched to onError)
-sum by (error_type) (
-  rate(requests_total_value{action_type="event", event_type="error"}[5m])
-)
+3. **Framework child spans** (Jaeger traces) — The `handled` and `cleaned_up` stages invoke Ballerina methods via `callMethod`, which creates auto-instrumented spans. Because the strand properties contain an `ObserverContext` whose parent has the per-file span set on it, these auto-instrumented spans become **children** of the parent span. This connects the entire file lifecycle into a single trace. Note: these spans also increment the runtime's `requests_total_value`, but that metric counts spans, not files — it must not be used for per-file counting.
 
-# All FTP activity on a specific node
-rate(requests_total_value{host="node-1", src_module=~"ballerina/ftp.*"}[1m])
+The per-file flow:
+
+```
+processContentCallbacks() — for each file:
+  │
+  │  [ftp / file-lifecycle] ─────────────────────────────── parent span (file.path tag)
+  │    │
+  │    ├─ file_events_total{file_stage="found"}            ← counter +1
+  │    │
+  │    ├─ file_events_total{file_stage="dispatched"}        ← counter +1
+  │    │
+  │    ├─ convertFileContent(onFileText) ───────────────────← timed
+  │    │   │
+  │    │   └─ file_databinding_duration_seconds                     ← gauge (seconds, with handler_name + outcome)
+  │    │
+  │    ├─ [onFileText] ────────────────────────────────────── child span (handled)
+  │    │   │
+  │    │   ├─ file_events_total{file_stage="handled"}       ← counter +1 (with outcome + error_type)
+  │    │   └─ file_resource_execution_duration_seconds              ← gauge (seconds, with handler_name + outcome)
+  │    │
+  │    ├─ [delete|move] ───────────────────────────────────── child span (cleaned_up)
+  │    │   │
+  │    │   └─ file_events_total{file_stage="cleaned_up"}    ← counter +1 (with outcome + error_type)
+  │    │
+  │    └─ finishSpan() ──────────────────────────────────── parent span closed
 ```
 
-### 7.4 Enabling Observability
+For a skipped file (no handler matched), no parent span is created:
+
+```
+  └─ file_events_total{file_stage="found", outcome="skipped"}     ← counter +1 (no further stages)
+```
+
+- **Poll cycles** are reported via `file_events_total{action_type="poll_cycle"}` because `poll()` is not auto-instrumented.
+- **Client operations** produce auto-instrumented spans with `action.type=client_operation`, visible in both `requests_total_value` and Jaeger. This is the only case where `requests_total_value` gives correct per-operation counts (one call = one span = one increment).
+
+### 7.4 Sample PromQL Queries
+
+All lifecycle stages can be queried uniformly from `file_events_total`:
+
+```promql
+# ── Poll health ──
+rate(file_events_total{action_type="poll_cycle", outcome="success"}[5m])
+rate(file_events_total{action_type="poll_cycle", outcome="failure"}[5m])
+
+# ── File lifecycle stages (all from file_events_total) ──
+rate(file_events_total{file_stage="found"}[5m])
+rate(file_events_total{file_stage="dispatched"}[5m])
+rate(file_events_total{file_stage="found", outcome="skipped"}[5m])
+rate(file_events_total{file_stage="handled"}[5m])
+rate(file_events_total{file_stage="cleaned_up"}[5m])
+
+# ── Handler outcomes (four-box grid) ──
+rate(file_events_total{file_stage="handled", outcome="success"}[5m])
+rate(file_events_total{file_stage="handled", outcome="failure"}[5m])
+rate(file_events_total{file_stage="cleaned_up", outcome="success"}[5m])
+rate(file_events_total{file_stage="cleaned_up", outcome="failure"}[5m])
+
+# ── Per-handler breakdown ──
+sum by (handler_name) (rate(file_events_total{file_stage="handled"}[5m]))
+
+# ── Handler errors by error type (captures errors from any code — FTP, HTTP, DB, etc.) ──
+sum by (error_type) (rate(file_events_total{file_stage="handled", outcome="failure"}[5m]))
+
+# ── Cleanup errors by type ──
+sum by (error_type) (rate(file_events_total{file_stage="cleaned_up", outcome="failure"}[5m]))
+
+# ── Data binding duration (p99 by handler) ──
+file_databinding_duration_seconds{quantile="0.99"}
+avg by (handler_name) (file_databinding_duration_seconds_mean)
+file_databinding_duration_seconds{handler_name="onFileJson", outcome="success", quantile="0.5"}
+
+# ── Resource execution duration (p99 by handler) ──
+file_resource_execution_duration_seconds{quantile="0.99"}
+avg by (handler_name) (file_resource_execution_duration_seconds_mean)
+file_resource_execution_duration_seconds{handler_name="onFileJson", outcome="success", quantile="0.5"}
+
+# ── Client operations (framework auto-instrumented spans) ──
+rate(requests_total_value{action_type="client_operation", operation_type="get"}[5m])
+rate(requests_total_value{action_type="client_operation", operation_type="put"}[5m])
+rate(requests_total_value{action_type="client_operation", operation_type="manage"}[5m])
+
+# ── Bytes transferred ──
+rate(file_bytes_transferred_total{operation_type="get"}[5m])   # total bytes read (client + listener)
+rate(file_bytes_transferred_total{operation_type="put"}[5m])   # total bytes written (client only)
+rate(file_bytes_transferred_total{type="client"}[5m])          # all client bytes (get + put)
+rate(file_bytes_transferred_total{type="listener"}[5m])        # all listener bytes (get)
+```
+
+### 7.5 Enabling Observability
 
 Observability must be enabled in the Ballerina runtime configuration. Add the following to `Config.toml`:
 
@@ -895,3 +1062,13 @@ tracingProvider="jaeger"
 ```
 
 Refer to the [Ballerina Observability documentation](https://ballerina.io/learn/observe-ballerina-programs/) for details on configuring reporters and exporters.
+
+### 7.6 Observability Safety Rules
+
+Observability must never break file operations. All metric and tracing calls are guarded by the following rules:
+
+1. **Exception isolation.** Every public method in the metrics and tracing utilities wraps its body in `try/catch(Throwable)` and swallows the exception with a debug-level log. A registry error, NPE, or any other observability failure must never propagate to callers. This follows the same pattern as `module-ballerina-sql`.
+
+2. **Early guard.** All metric methods check `ObserveUtils.isMetricsEnabled()` and return immediately when metrics are disabled. Tracing factory methods check `ObserveUtils.isObservabilityEnabled()` and return `null`. This ensures zero overhead when observability is off.
+
+3. **Null-safe returns.** Tracing methods that return strand property maps return `null` on failure — the same value returned when observability is disabled. Callers already handle `null` (the `StrandMetadata` constructor accepts it), so no caller changes are required.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=2.20.3-SNAPSHOT
+version=2.21.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 testngVersion=7.6.1

--- a/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/client/FtpClient.java
@@ -173,6 +173,13 @@ public class FtpClient {
         if (result instanceof BError bError) {
             String errorType = bError.getType() != null ? bError.getType().getName() : FtpMetricsUtil.UNKNOWN;
             FtpTracingUtil.sendErrorMetricsOnCurrentFrame(env, errorType);
+        } else {
+            // Tag successful client operations with outcome=success
+            io.ballerina.runtime.observability.ObserverContext ctx =
+                    io.ballerina.runtime.observability.ObserveUtils.getObserverContextOfCurrentFrame(env);
+            if (ctx != null) {
+                ctx.addTag("outcome", FtpMetricsUtil.OUTCOME_SUCCESS);
+            }
         }
         return result;
     }
@@ -263,7 +270,7 @@ public class FtpClient {
         clientEndpoint.addNativeData(FtpConstants.ENDPOINT_CONFIG_PORT, port);
         clientEndpoint.addNativeData(FtpConstants.ENDPOINT_CONFIG_PROTOCOL, protocol);
         String hostPort = port > 0 ? host + ":" + port : host;
-        clientEndpoint.addNativeData(REMOTE_URL, protocol + "://" + hostPort);
+        clientEndpoint.addNativeData(REMOTE_URL, hostPort);
         return null;
     }
 
@@ -483,7 +490,11 @@ public class FtpClient {
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
                     if (content instanceof byte[]) {
-                        return convertToBallerinaByteArray((byte[]) content);
+                        byte[] bytes = (byte[]) content;
+                        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                                FtpMetricsUtil.OPERATION_TYPE_GET, bytes.length);
+                        return convertToBallerinaByteArray(bytes);
                     }
                     return content;
                 },
@@ -501,7 +512,11 @@ public class FtpClient {
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
                     if (content instanceof byte[]) {
-                        return convertBytesToString((byte[]) content);
+                        byte[] bytes = (byte[]) content;
+                        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                                FtpMetricsUtil.OPERATION_TYPE_GET, bytes.length);
+                        return convertBytesToString(bytes);
                     }
                     return content;
                 },
@@ -520,7 +535,11 @@ public class FtpClient {
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
                     if (content instanceof byte[]) {
-                        return convertBytesToJson((byte[]) content, typeDesc.getDescribingType(), laxDataBinding,
+                        byte[] bytes = (byte[]) content;
+                        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                                FtpMetricsUtil.OPERATION_TYPE_GET, bytes.length);
+                        return convertBytesToJson(bytes, typeDesc.getDescribingType(), laxDataBinding,
                                 filePath.getValue());
                     }
                     return content;
@@ -540,7 +559,11 @@ public class FtpClient {
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
                     if (content instanceof byte[]) {
-                        return convertBytesToXml((byte[]) content, typeDesc.getDescribingType(), laxDataBinding,
+                        byte[] bytes = (byte[]) content;
+                        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                                FtpMetricsUtil.OPERATION_TYPE_GET, bytes.length);
+                        return convertBytesToXml(bytes, typeDesc.getDescribingType(), laxDataBinding,
                                 filePath.getValue());
                     }
                     return content;
@@ -562,7 +585,11 @@ public class FtpClient {
                 () -> {
                     Object content = getAllContent(env, clientConnector, filePath);
                     if (content instanceof byte[]) {
-                        return convertBytesToCsv(env, (byte[]) content, typeDesc.getDescribingType(),
+                        byte[] bytes = (byte[]) content;
+                        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                                FtpMetricsUtil.OPERATION_TYPE_GET, bytes.length);
+                        return convertBytesToCsv(env, bytes, typeDesc.getDescribingType(),
                                 laxDataBinding, csvFailSafe, fileNamePrefix, filePath.getValue());
                     }
                     return content;
@@ -791,7 +818,11 @@ public class FtpClient {
                                   BString options) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
-        InputStream stream = new ByteArrayInputStream(inputContent.getBytes());
+        byte[] bytes = inputContent.getBytes();
+        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                FtpMetricsUtil.OPERATION_TYPE_PUT, bytes.length);
+        InputStream stream = new ByteArrayInputStream(bytes);
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
         return sendTraces(putGenericAction(env, clientConnector, path, options, message),
                 env, clientConnector);
@@ -801,7 +832,11 @@ public class FtpClient {
                                  BString options) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
-        InputStream stream = new ByteArrayInputStream(inputContent.getValue().getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = inputContent.getValue().getBytes(StandardCharsets.UTF_8);
+        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                FtpMetricsUtil.OPERATION_TYPE_PUT, bytes.length);
+        InputStream stream = new ByteArrayInputStream(bytes);
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
         return sendTraces(putGenericAction(env, clientConnector, path, options, message),
                 env, clientConnector);
@@ -811,7 +846,11 @@ public class FtpClient {
                                  BString options) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
-        InputStream stream = new ByteArrayInputStream(inputContent.getValue().getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = inputContent.getValue().getBytes(StandardCharsets.UTF_8);
+        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                FtpMetricsUtil.OPERATION_TYPE_PUT, bytes.length);
+        InputStream stream = new ByteArrayInputStream(bytes);
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
         return sendTraces(putGenericAction(env, clientConnector, path, options, message),
                 env, clientConnector);
@@ -821,7 +860,11 @@ public class FtpClient {
                                 BString options) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
-        InputStream stream = new ByteArrayInputStream(inputContent.toString().getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = inputContent.toString().getBytes(StandardCharsets.UTF_8);
+        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                FtpMetricsUtil.OPERATION_TYPE_PUT, bytes.length);
+        InputStream stream = new ByteArrayInputStream(bytes);
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
         return sendTraces(putGenericAction(env, clientConnector, path, options, message),
                 env, clientConnector);
@@ -833,7 +876,11 @@ public class FtpClient {
                 getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_PUT, path.getValue());
         boolean addHeader = !options.getValue().equals(FtpConstants.WRITE_OPTION_APPEND);
         String convertToCsv = CSVUtils.convertToCsv(inputContent, addHeader);
-        InputStream stream = new ByteArrayInputStream(convertToCsv.getBytes(StandardCharsets.UTF_8));
+        byte[] bytes = convertToCsv.getBytes(StandardCharsets.UTF_8);
+        FtpMetricsUtil.reportBytesTransferred(getRemoteUrl(clientConnector),
+                getProtocol(clientConnector), FtpMetricsUtil.CONTEXT_CLIENT,
+                FtpMetricsUtil.OPERATION_TYPE_PUT, bytes.length);
+        InputStream stream = new ByteArrayInputStream(bytes);
         RemoteFileSystemMessage message = new RemoteFileSystemMessage(stream);
         return sendTraces(putGenericAction(env, clientConnector, path, options, message),
                 env, clientConnector);
@@ -1010,7 +1057,7 @@ public class FtpClient {
 
     public static Object delete(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.DELETE, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
@@ -1020,7 +1067,7 @@ public class FtpClient {
 
     public static Object isDirectory(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.ISDIR, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeIsDirectoryAction(remoteFileSystemBaseMessage, balFuture);
@@ -1030,7 +1077,7 @@ public class FtpClient {
 
     public static Object list(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.LIST, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeListAction(remoteFileSystemBaseMessage, balFuture);
@@ -1040,7 +1087,7 @@ public class FtpClient {
 
     public static Object mkdir(Environment env, BObject clientConnector, BString path) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, path.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE, path.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, path, FtpAction.MKDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
@@ -1050,7 +1097,7 @@ public class FtpClient {
 
     public static Object rename(Environment env, BObject clientConnector, BString origin, BString destination) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN,
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE,
                 origin.getValue(), destination.getValue());
         return sendTraces(
                 executeTwoPathAction(env, clientConnector, origin, destination, FtpAction.RENAME),
@@ -1059,7 +1106,7 @@ public class FtpClient {
 
     public static Object move(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN,
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE,
                 sourcePath.getValue(), destinationPath.getValue());
         return sendTraces(
                 executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.RENAME),
@@ -1068,7 +1115,7 @@ public class FtpClient {
 
     public static Object copy(Environment env, BObject clientConnector, BString sourcePath, BString destinationPath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN,
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE,
                 sourcePath.getValue(), destinationPath.getValue());
         return sendTraces(
                 executeTwoPathAction(env, clientConnector, sourcePath, destinationPath, FtpAction.COPY),
@@ -1077,7 +1124,7 @@ public class FtpClient {
 
     public static Object exists(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector,
                 filePath, FtpAction.EXISTS, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
@@ -1089,7 +1136,7 @@ public class FtpClient {
 
     public static Object rmdir(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.RMDIR, true,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeGenericAction();
@@ -1099,7 +1146,7 @@ public class FtpClient {
 
     public static Object size(Environment env, BObject clientConnector, BString filePath) {
         FtpTracingUtil.sendMetricsData(env, getRemoteUrl(clientConnector),
-                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_ADMIN, filePath.getValue());
+                getProtocol(clientConnector), FtpMetricsUtil.OPERATION_TYPE_MANAGE, filePath.getValue());
         return sendTraces(executeSinglePathAction(env, clientConnector, filePath, FtpAction.SIZE, false,
                 balFuture -> remoteFileSystemBaseMessage -> {
                     FtpClientHelper.executeSizeAction(remoteFileSystemBaseMessage, balFuture);

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpMetricsUtil.java
@@ -22,11 +22,18 @@ import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.metrics.DefaultMetricRegistry;
 import io.ballerina.runtime.observability.metrics.MetricId;
 import io.ballerina.runtime.observability.metrics.MetricRegistry;
+import io.ballerina.runtime.observability.metrics.StatisticConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
+import java.time.Duration;
 
 /**
  * Utility class for recording FTP connector metrics.
+ *
+ * <p>All public methods swallow exceptions internally so that observability failures
+ * never break file operations. This follows the same pattern as {@code module-ballerina-sql}.
  *
  * <p>Metrics published:
  * <ul>
@@ -34,12 +41,35 @@ import java.net.InetAddress;
  * </ul>
  */
 public class FtpMetricsUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(FtpMetricsUtil.class);
     private static final String CONNECTOR_NAME = "ftp";
+    private static final String FILE_CONNECTOR_NAME = "file";
     private static final String[] METRIC_ACTIVE_CONNECTIONS = {
             "active_connections", "Number of active FTP/FTPS/SFTP connections"};
+    private static final String[] METRIC_BYTES_TRANSFERRED = {
+            "bytes_transferred_total", "Total bytes read or written across operations"};
+    private static final String[] METRIC_FILE_EVENTS = {
+            "events_total", "Total file lifecycle and poll events"};
+    private static final String[] METRIC_DATABINDING_DURATION = {
+            "databinding_duration_seconds", "Time taken to fetch and convert file content"};
+    private static final String[] METRIC_RESOURCE_EXECUTION_DURATION = {
+            "resource_execution_duration_seconds", "Time taken to execute the resource/handler method"};
+
+    private static final StatisticConfig DURATION_STATISTIC_CONFIG = StatisticConfig.builder()
+            .percentiles(0.5, 0.75, 0.9, 0.95, 0.99)
+            .expiry(Duration.ofMinutes(5))
+            .buckets(10)
+            .build();
 
     /** Sentinel used when a URL or protocol value is unavailable. */
     public static final String UNKNOWN = "unknown";
+
+    /** Sentinel used when a tag is not applicable for a given stage, ensuring consistent label sets. */
+    public static final String NONE = "none";
+
+    /** Module tag value identifying the FTP module. */
+    public static final String MODULE_FTP = "ftp";
 
     /** Context tag value for FTP client operations. */
     public static final String CONTEXT_CLIENT = "client";
@@ -64,13 +94,50 @@ public class FtpMetricsUtil {
 
     /** Operation-type tag value: admin/filesystem operations ({@code delete}, {@code rename}, {@code move},
      *  {@code copy}, {@code mkdir}, {@code rmdir}, {@code isDirectory}, {@code list}, {@code exists}, {@code size}). */
-    public static final String OPERATION_TYPE_ADMIN = "admin";
+    public static final String OPERATION_TYPE_MANAGE = "manage";
 
     /** Action-type tag value for FTP client operations (get, put, delete, etc.). */
-    public static final String ACTION_TYPE_OPERATION = "operation";
+    public static final String ACTION_TYPE_OPERATION = "client_operation";
 
     /** Action-type tag value for FTP listener event dispatches (create, delete, error). */
-    public static final String ACTION_TYPE_EVENT = "event";
+    public static final String ACTION_TYPE_EVENT = "file_event";
+
+    /** Action-type tag value for poll cycles. */
+    public static final String ACTION_TYPE_POLL = "poll_cycle";
+
+    // File lifecycle stage constants
+    /** File stage: file discovered during poll or event. */
+    public static final String FILE_STAGE_FOUND = "found";
+    /** File stage: file matched to a handler and handed over. */
+    public static final String FILE_STAGE_DISPATCHED = "dispatched";
+    /** File stage: handler invocation completed. */
+    public static final String FILE_STAGE_HANDLED = "handled";
+    /** File stage: post-processing action completed (move/delete). */
+    public static final String FILE_STAGE_CLEANED_UP = "cleaned_up";
+
+    // Outcome constants
+    /** Outcome: operation succeeded. */
+    public static final String OUTCOME_SUCCESS = "success";
+    /** Outcome: operation failed. */
+    public static final String OUTCOME_FAILURE = "failure";
+    /** Outcome: file found but skipped (e.g. no handler matched). */
+    public static final String OUTCOME_SKIPPED = "skipped";
+
+    // Cleanup action constants
+    /** Cleanup action: file moved after processing. */
+    public static final String CLEANUP_ACTION_MOVE = "move";
+    /** Cleanup action: file deleted after processing. */
+    public static final String CLEANUP_ACTION_DELETE = "delete";
+
+    // Failure reason constants
+    /** Failure reason: file found but no handler matched. */
+    public static final String FAILURE_NO_HANDLER_MATCHED = "no_handler_matched";
+    /** Failure reason: content binding failed. */
+    public static final String FAILURE_BINDING_FAILED = "binding_failed";
+    /** Failure reason: move post-processing failed. */
+    public static final String FAILURE_MOVE_FAILED = "move_failed";
+    /** Failure reason: delete post-processing failed. */
+    public static final String FAILURE_DELETE_FAILED = "delete_failed";
 
     private static final MetricRegistry metricRegistry = DefaultMetricRegistry.getInstance();
 
@@ -91,7 +158,8 @@ public class FtpMetricsUtil {
     }
 
     /**
-     * Increments the active-connections gauge when a new FTP client or listener is created.
+     * Increments the {@code ftp_active_connections} gauge when a new FTP client or listener is created.
+     * Retained for backward compatibility.
      *
      * @param url      host:port of the remote server
      * @param protocol "ftp", "ftps", or "sftp"
@@ -101,12 +169,18 @@ public class FtpMetricsUtil {
         if (!ObserveUtils.isMetricsEnabled()) {
             return;
         }
-        FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
-        incrementGauge(observerContext, METRIC_ACTIVE_CONNECTIONS[0], METRIC_ACTIVE_CONNECTIONS[1]);
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+            metricRegistry.gauge(new MetricId(CONNECTOR_NAME + "_" + METRIC_ACTIVE_CONNECTIONS[0],
+                    METRIC_ACTIVE_CONNECTIONS[1], observerContext.getAllTags())).increment();
+        } catch (Throwable t) {
+            log.debug("Failed to report new connection metric", t);
+        }
     }
 
     /**
-     * Decrements the active-connections gauge when an FTP client or listener is closed.
+     * Decrements the {@code ftp_active_connections} gauge when an FTP client or listener is closed.
+     * Retained for backward compatibility.
      *
      * @param url      host:port of the remote server
      * @param protocol "ftp", "ftps", or "sftp"
@@ -116,18 +190,153 @@ public class FtpMetricsUtil {
         if (!ObserveUtils.isMetricsEnabled()) {
             return;
         }
-        FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
-        decrementGauge(observerContext, METRIC_ACTIVE_CONNECTIONS[0], METRIC_ACTIVE_CONNECTIONS[1]);
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+            metricRegistry.gauge(new MetricId(CONNECTOR_NAME + "_" + METRIC_ACTIVE_CONNECTIONS[0],
+                    METRIC_ACTIVE_CONNECTIONS[1], observerContext.getAllTags())).decrement();
+        } catch (Throwable t) {
+            log.debug("Failed to report connection close metric", t);
+        }
     }
 
-    private static void incrementGauge(FtpObserverContext observerContext, String name, String desc) {
-        metricRegistry.gauge(new MetricId(CONNECTOR_NAME + "_" + name, desc, observerContext.getAllTags()))
-                .increment();
+    /**
+     * Reports bytes transferred during a file operation (get or put).
+     *
+     * @param url           host:port of the remote server
+     * @param protocol      "ftp", "ftps", or "sftp"
+     * @param context       {@link #CONTEXT_CLIENT} or {@link #CONTEXT_LISTENER}
+     * @param operationType {@link #OPERATION_TYPE_GET} or {@link #OPERATION_TYPE_PUT}
+     * @param bytes         number of bytes transferred
+     */
+    public static void reportBytesTransferred(String url, String protocol, String context,
+                                              String operationType, long bytes) {
+        if (!ObserveUtils.isMetricsEnabled() || bytes <= 0) {
+            return;
+        }
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+            observerContext.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
+            metricRegistry.counter(new MetricId(FILE_CONNECTOR_NAME + "_" + METRIC_BYTES_TRANSFERRED[0],
+                    METRIC_BYTES_TRANSFERRED[1], observerContext.getAllTags())).increment(bytes);
+        } catch (Throwable t) {
+            log.debug("Failed to report bytes transferred metric", t);
+        }
     }
 
-    private static void decrementGauge(FtpObserverContext observerContext, String name, String desc) {
-        metricRegistry.gauge(new MetricId(CONNECTOR_NAME + "_" + name, desc, observerContext.getAllTags()))
-                .decrement();
+    /**
+     * Reports a file lifecycle stage event. Publishes an explicit counter that mirrors the
+     * {@code requests_total_value} tag structure for stages where the framework cannot
+     * create auto-instrumented spans (found, dispatched).
+     *
+     * @param url           host:port of the remote server
+     * @param protocol      "ftp", "ftps", or "sftp"
+     * @param fileStage     lifecycle stage (found, dispatched, handled, cleaned_up)
+     * @param outcome       outcome tag value, or {@code null}
+     * @param errorType     error type (Ballerina error name or predefined reason), or {@code null}
+     * @param handlerName   handler method name, or {@code null}
+     */
+    public static void reportFileStage(String url, String protocol, String watchedPath, String fileStage,
+                                       String outcome, String errorType, String handlerName) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_LISTENER, url, protocol);
+            observerContext.addTag(FtpObserverContext.TAG_ACTION_TYPE, ACTION_TYPE_EVENT);
+            observerContext.addTag(FtpObserverContext.TAG_FILE_STAGE, fileStage);
+            observerContext.addTag(FtpObserverContext.TAG_WATCHED_PATH, watchedPath != null ? watchedPath : NONE);
+            observerContext.addTag(FtpObserverContext.TAG_OUTCOME, outcome != null ? outcome : NONE);
+            observerContext.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType != null ? errorType : NONE);
+            observerContext.addTag(FtpObserverContext.TAG_HANDLER_NAME, handlerName != null ? handlerName : NONE);
+            String instanceUrl = getInstanceUrl();
+            observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl != null ? instanceUrl : NONE);
+            metricRegistry.counter(new MetricId(FILE_CONNECTOR_NAME + "_" + METRIC_FILE_EVENTS[0],
+                    METRIC_FILE_EVENTS[1], observerContext.getAllTags())).increment();
+        } catch (Throwable t) {
+            log.debug("Failed to report file stage metric", t);
+        }
+    }
+
+    /**
+     * Reports a poll cycle completion.
+     *
+     * @param url         host:port of the remote server
+     * @param protocol    "ftp", "ftps", or "sftp"
+     * @param watchedPath the monitored directory path, or {@code null}
+     * @param outcome     {@link #OUTCOME_SUCCESS} or {@link #OUTCOME_FAILURE}
+     */
+    public static void reportPollCycle(String url, String protocol, String watchedPath, String outcome) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_LISTENER, url, protocol);
+            observerContext.addTag(FtpObserverContext.TAG_ACTION_TYPE, ACTION_TYPE_POLL);
+            observerContext.addTag(FtpObserverContext.TAG_OUTCOME, outcome != null ? outcome : NONE);
+            observerContext.addTag(FtpObserverContext.TAG_WATCHED_PATH, watchedPath != null ? watchedPath : NONE);
+            String instanceUrl = getInstanceUrl();
+            observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl != null ? instanceUrl : NONE);
+            metricRegistry.counter(new MetricId(FILE_CONNECTOR_NAME + "_" + METRIC_FILE_EVENTS[0],
+                    METRIC_FILE_EVENTS[1], observerContext.getAllTags())).increment();
+        } catch (Throwable t) {
+            log.debug("Failed to report poll cycle metric", t);
+        }
+    }
+
+    /**
+     * Reports the time taken to fetch and convert file content (data binding).
+     *
+     * @param url          host:port of the remote server
+     * @param protocol     "ftp", "ftps", or "sftp"
+     * @param handlerName  handler method name (e.g. "onFileJson")
+     * @param outcome      {@link #OUTCOME_SUCCESS} or {@link #OUTCOME_FAILURE}
+     * @param durationMs   duration in milliseconds (converted to seconds before recording)
+     */
+    public static void reportDatabindingDuration(String url, String protocol, String handlerName,
+                                                  String outcome, long durationMs) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_LISTENER, url, protocol);
+            if (handlerName != null) {
+                observerContext.addTag(FtpObserverContext.TAG_HANDLER_NAME, handlerName);
+            }
+            observerContext.addTag(FtpObserverContext.TAG_OUTCOME, outcome);
+            metricRegistry.gauge(new MetricId(FILE_CONNECTOR_NAME + "_" + METRIC_DATABINDING_DURATION[0],
+                    METRIC_DATABINDING_DURATION[1], observerContext.getAllTags()),
+                    DURATION_STATISTIC_CONFIG).setValue(durationMs / 1000.0);
+        } catch (Throwable t) {
+            log.debug("Failed to report databinding duration metric", t);
+        }
+    }
+
+    /**
+     * Reports the time taken to execute the user's resource/handler method.
+     *
+     * @param url          host:port of the remote server
+     * @param protocol     "ftp", "ftps", or "sftp"
+     * @param handlerName  handler method name (e.g. "onFileJson")
+     * @param outcome      {@link #OUTCOME_SUCCESS} or {@link #OUTCOME_FAILURE}
+     * @param durationMs   duration in milliseconds (converted to seconds before recording)
+     */
+    public static void reportResourceExecutionDuration(String url, String protocol, String handlerName,
+                                                        String outcome, long durationMs) {
+        if (!ObserveUtils.isMetricsEnabled()) {
+            return;
+        }
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(CONTEXT_LISTENER, url, protocol);
+            if (handlerName != null) {
+                observerContext.addTag(FtpObserverContext.TAG_HANDLER_NAME, handlerName);
+            }
+            observerContext.addTag(FtpObserverContext.TAG_OUTCOME, outcome);
+            metricRegistry.gauge(new MetricId(FILE_CONNECTOR_NAME + "_" + METRIC_RESOURCE_EXECUTION_DURATION[0],
+                    METRIC_RESOURCE_EXECUTION_DURATION[1], observerContext.getAllTags()),
+                    DURATION_STATISTIC_CONFIG).setValue(durationMs / 1000.0);
+        } catch (Throwable t) {
+            log.debug("Failed to report resource execution duration metric", t);
+        }
     }
 
     private FtpMetricsUtil() {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpObserverContext.java
@@ -26,7 +26,7 @@ import io.ballerina.runtime.observability.ObserverContext;
  */
 public class FtpObserverContext extends ObserverContext {
 
-    static final String TAG_CONTEXT = "context";
+    static final String TAG_CONTEXT = "type";
     static final String TAG_REMOTE_URL = "remote.url";
     static final String TAG_PROTOCOL = "protocol";
 
@@ -38,8 +38,19 @@ public class FtpObserverContext extends ObserverContext {
     static final String TAG_ACTION_TYPE = "action.type";
     static final String TAG_INSTANCE_URL = "host";
 
+    // New tags from the unified observability spec
+    static final String TAG_MODULE = "module";
+    static final String TAG_FILE_STAGE = "file.stage";
+    static final String TAG_HANDLER_NAME = "handler.name";
+    static final String TAG_CLEANUP_ACTION = "cleanup.action";
+    static final String TAG_OUTCOME = "outcome";
+    static final String TAG_FILE_SIZE = "file.size";
+    static final String TAG_FILE_MODIFIED_TIME = "file.modified_time";
+    static final String TAG_WATCHED_PATH = "watched.path";
+
     FtpObserverContext(String context) {
         addTag(TAG_CONTEXT, context);
+        addTag(TAG_MODULE, FtpMetricsUtil.MODULE_FTP);
     }
 
     public FtpObserverContext(String context, String remoteUrl, String protocol) {

--- a/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/observability/FtpTracingUtil.java
@@ -23,6 +23,8 @@ import io.ballerina.runtime.observability.ObservabilityConstants;
 import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.ObserverContext;
 import io.ballerina.runtime.observability.tracer.BSpan;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +47,86 @@ import java.util.Map;
  */
 public class FtpTracingUtil {
 
+    private static final Logger log = LoggerFactory.getLogger(FtpTracingUtil.class);
+
     private FtpTracingUtil() {
+    }
+
+    /**
+     * Creates a per-file parent span that covers the entire file lifecycle (found → cleaned_up).
+     * The returned context has a {@link BSpan} set on it. When this context is set as the parent
+     * of strand properties (via {@link #setParentContext}), the runtime automatically creates
+     * child spans for each {@code callMethod} invocation.
+     *
+     * @param url      host:port of the remote server
+     * @param protocol "ftp", "ftps", or "sftp"
+     * @param filePath path of the file being processed (added as a trace-only tag)
+     * @return context with parent span, or {@code null} if observability is disabled
+     */
+    public static FtpObserverContext createFileLifecycleContext(String url, String protocol, String filePath) {
+        if (!ObserveUtils.isObservabilityEnabled()) {
+            return null;
+        }
+        try {
+            FtpObserverContext ctx = new FtpObserverContext(
+                    FtpMetricsUtil.CONTEXT_LISTENER, url, protocol);
+            ctx.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_EVENT);
+            String instanceUrl = FtpMetricsUtil.getInstanceUrl();
+            if (instanceUrl != null) {
+                ctx.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+            }
+            BSpan span = BSpan.start("ftp", "file-lifecycle", false);
+            if (filePath != null) {
+                span.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
+            }
+            ctx.setSpan(span);
+            return ctx;
+        } catch (Throwable t) {
+            log.debug("Failed to create file lifecycle context", t);
+            return null;
+        }
+    }
+
+    /**
+     * Sets a parent context on the observer context inside strand properties, so that the
+     * auto-instrumented span created by {@code callMethod} becomes a child of the parent's span.
+     *
+     * @param strandProperties the strand properties map (may be null)
+     * @param parentCtx        the parent context with a span set on it (may be null)
+     */
+    public static void setParentContext(Map<String, Object> strandProperties,
+                                         FtpObserverContext parentCtx) {
+        if (strandProperties == null || parentCtx == null) {
+            return;
+        }
+        try {
+            Object ctxObj = strandProperties.get(ObservabilityConstants.KEY_OBSERVER_CONTEXT);
+            if (ctxObj instanceof ObserverContext ctx) {
+                ctx.setParent(parentCtx);
+            }
+        } catch (Throwable t) {
+            log.debug("Failed to set parent context on strand properties", t);
+        }
+    }
+
+    /**
+     * Finishes the per-file parent span. Must be called exactly once per file, after all
+     * processing (handler + cleanup) has completed.
+     *
+     * @param parentCtx the parent context returned by {@link #createFileLifecycleContext}, or null
+     */
+    public static void finishFileLifecycleSpan(FtpObserverContext parentCtx) {
+        if (parentCtx == null) {
+            return;
+        }
+        try {
+            BSpan span = parentCtx.getSpan();
+            if (span != null) {
+                span.finishSpan();
+            }
+        } catch (Throwable t) {
+            log.debug("Failed to finish file lifecycle span", t);
+        }
     }
 
     /**
@@ -67,16 +148,21 @@ public class FtpTracingUtil {
         if (!ObserveUtils.isObservabilityEnabled()) {
             return null;
         }
-        FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
-        observerContext.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_EVENT);
-        String instanceUrl = FtpMetricsUtil.getInstanceUrl();
-        if (instanceUrl != null) {
-            observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+            observerContext.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_EVENT);
+            String instanceUrl = FtpMetricsUtil.getInstanceUrl();
+            if (instanceUrl != null) {
+                observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+            }
+            observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
+            return properties;
+        } catch (Throwable t) {
+            log.debug("Failed to create strand properties", t);
+            return null;
         }
-        observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
-        Map<String, Object> properties = new HashMap<>();
-        properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
-        return properties;
     }
 
     /**
@@ -86,6 +172,90 @@ public class FtpTracingUtil {
     public static Map<String, Object> createStrandProperties(String context, String url, String protocol,
                                                               String eventType) {
         return createStrandProperties(context, url, protocol, eventType, null);
+    }
+
+    /**
+     * Creates strand properties for a listener file lifecycle event with file stage, handler name,
+     * and file metadata. This is the primary method for content-based handler dispatch.
+     *
+     * @param context     context tag
+     * @param url         host:port
+     * @param protocol    protocol string
+     * @param eventType   event type (e.g. "create")
+     * @param fileStage   file lifecycle stage (found, dispatched, handled, cleaned_up)
+     * @param handlerName handler method name (e.g. "onFileJson"), or {@code null}
+     * @param fileSize    file size in bytes, or -1 if unknown
+     * @param modifiedTime last-modified timestamp, or -1 if unknown
+     * @return properties map, or {@code null} if observability is disabled
+     */
+    public static Map<String, Object> createFileStageStrandProperties(String context, String url, String protocol,
+                                                                       String eventType, String fileStage,
+                                                                       String handlerName, long fileSize,
+                                                                       long modifiedTime) {
+        if (!ObserveUtils.isObservabilityEnabled()) {
+            return null;
+        }
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+            observerContext.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_EVENT);
+            String instanceUrl = FtpMetricsUtil.getInstanceUrl();
+            if (instanceUrl != null) {
+                observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+            }
+            observerContext.addTag(FtpObserverContext.TAG_EVENT_TYPE, eventType);
+            observerContext.addTag(FtpObserverContext.TAG_FILE_STAGE, fileStage);
+            if (handlerName != null) {
+                observerContext.addTag(FtpObserverContext.TAG_HANDLER_NAME, handlerName);
+            }
+            if (fileSize >= 0) {
+                observerContext.addProperty(FtpObserverContext.TAG_FILE_SIZE, fileSize);
+            }
+            if (modifiedTime >= 0) {
+                observerContext.addProperty(FtpObserverContext.TAG_FILE_MODIFIED_TIME, modifiedTime);
+            }
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
+            return properties;
+        } catch (Throwable t) {
+            log.debug("Failed to create file stage strand properties", t);
+            return null;
+        }
+    }
+
+    /**
+     * Creates strand properties for a cleanup (post-processing) span.
+     *
+     * @param context       context tag
+     * @param url           host:port
+     * @param protocol      protocol string
+     * @param cleanupAction cleanup action type (move, delete, none)
+     * @param handlerName   handler method name that triggered this cleanup
+     * @return properties map, or {@code null} if observability is disabled
+     */
+    public static Map<String, Object> createCleanupStrandProperties(String context, String url, String protocol,
+                                                                     String cleanupAction, String handlerName) {
+        if (!ObserveUtils.isObservabilityEnabled()) {
+            return null;
+        }
+        try {
+            FtpObserverContext observerContext = new FtpObserverContext(context, url, protocol);
+            observerContext.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_EVENT);
+            String instanceUrl = FtpMetricsUtil.getInstanceUrl();
+            if (instanceUrl != null) {
+                observerContext.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+            }
+            observerContext.addTag(FtpObserverContext.TAG_FILE_STAGE, FtpMetricsUtil.FILE_STAGE_CLEANED_UP);
+            observerContext.addTag(FtpObserverContext.TAG_CLEANUP_ACTION, cleanupAction);
+            if (handlerName != null) {
+                observerContext.addTag(FtpObserverContext.TAG_HANDLER_NAME, handlerName);
+            }
+            Map<String, Object> properties = new HashMap<>();
+            properties.put(ObservabilityConstants.KEY_OBSERVER_CONTEXT, observerContext);
+            return properties;
+        } catch (Throwable t) {
+            log.debug("Failed to create cleanup strand properties", t);
+            return null;
+        }
     }
 
     /**
@@ -101,13 +271,47 @@ public class FtpTracingUtil {
      */
     public static Map<String, Object> createErrorStrandProperties(String context, String url, String protocol,
                                                                    String filePath, String errorType) {
-        Map<String, Object> props = createStrandProperties(context, url, protocol,
-                FtpMetricsUtil.EVENT_TYPE_ERROR, filePath);
-        if (props != null) {
-            FtpObserverContext ctx = (FtpObserverContext) props.get(ObservabilityConstants.KEY_OBSERVER_CONTEXT);
-            ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
+        try {
+            Map<String, Object> props = createStrandProperties(context, url, protocol,
+                    FtpMetricsUtil.EVENT_TYPE_ERROR, filePath);
+            if (props != null) {
+                FtpObserverContext ctx = (FtpObserverContext) props.get(
+                        ObservabilityConstants.KEY_OBSERVER_CONTEXT);
+                ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
+                ctx.addTag(FtpObserverContext.TAG_OUTCOME, FtpMetricsUtil.OUTCOME_FAILURE);
+            }
+            return props;
+        } catch (Throwable t) {
+            log.debug("Failed to create error strand properties", t);
+            return null;
         }
-        return props;
+    }
+
+    /**
+     * Adds outcome and optional error type tags to strand properties.
+     *
+     * @param strandProperties the strand properties map (may be null)
+     * @param outcome          success or failure
+     * @param errorType        error type (Ballerina error name or predefined reason), or null
+     */
+    public static void addOutcomeToStrandProperties(Map<String, Object> strandProperties, String outcome,
+                                                     String errorType) {
+        if (strandProperties == null) {
+            return;
+        }
+        try {
+            FtpObserverContext ctx = (FtpObserverContext) strandProperties.get(
+                    ObservabilityConstants.KEY_OBSERVER_CONTEXT);
+            if (ctx == null) {
+                return;
+            }
+            ctx.addTag(FtpObserverContext.TAG_OUTCOME, outcome);
+            if (errorType != null) {
+                ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
+            }
+        } catch (Throwable t) {
+            log.debug("Failed to add outcome to strand properties", t);
+        }
     }
 
     /**
@@ -142,25 +346,75 @@ public class FtpTracingUtil {
     public static void sendMetricsData(Environment env, String url, String protocol,
                                        String operationType, String filePath,
                                        String destinationPath) {
-        ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
-        if (ctx == null) {
-            return;
-        }
-        ctx.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_OPERATION);
-        ctx.addTag(FtpObserverContext.TAG_CONTEXT, FtpMetricsUtil.CONTEXT_CLIENT);
-        ctx.addTag(FtpObserverContext.TAG_REMOTE_URL, url);
-        ctx.addTag(FtpObserverContext.TAG_PROTOCOL, protocol);
-        ctx.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
-        String instanceUrl = FtpMetricsUtil.getInstanceUrl();
-        if (instanceUrl != null) {
-            ctx.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
-        }
-        BSpan span = ctx.getSpan();
-        if (span != null) {
-            span.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
-            if (destinationPath != null) {
-                span.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
+        try {
+            ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
+            if (ctx == null) {
+                return;
             }
+            ctx.addTag(FtpObserverContext.TAG_MODULE, FtpMetricsUtil.MODULE_FTP);
+            ctx.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_OPERATION);
+            ctx.addTag(FtpObserverContext.TAG_CONTEXT, FtpMetricsUtil.CONTEXT_CLIENT);
+            ctx.addTag(FtpObserverContext.TAG_REMOTE_URL, url);
+            ctx.addTag(FtpObserverContext.TAG_PROTOCOL, protocol);
+            ctx.addTag(FtpObserverContext.TAG_OPERATION_TYPE, operationType);
+            String instanceUrl = FtpMetricsUtil.getInstanceUrl();
+            if (instanceUrl != null) {
+                ctx.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+            }
+            BSpan span = ctx.getSpan();
+            if (span != null) {
+                span.addTag(FtpObserverContext.TAG_FILE_PATH, filePath);
+                if (destinationPath != null) {
+                    span.addTag(FtpObserverContext.TAG_DESTINATION_PATH, destinationPath);
+                }
+            }
+        } catch (Throwable t) {
+            log.debug("Failed to send metrics data", t);
+        }
+    }
+
+    /**
+     * Tags the auto-instrumented span of the current frame as a poll cycle span.
+     *
+     * @param env      the current Ballerina environment
+     * @param url      remote URL
+     * @param protocol protocol string
+     */
+    public static void sendPollMetricsData(Environment env, String url, String protocol) {
+        try {
+            ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
+            if (ctx == null) {
+                return;
+            }
+            ctx.addTag(FtpObserverContext.TAG_MODULE, FtpMetricsUtil.MODULE_FTP);
+            ctx.addTag(FtpObserverContext.TAG_ACTION_TYPE, FtpMetricsUtil.ACTION_TYPE_POLL);
+            ctx.addTag(FtpObserverContext.TAG_CONTEXT, FtpMetricsUtil.CONTEXT_LISTENER);
+            ctx.addTag(FtpObserverContext.TAG_REMOTE_URL, url != null ? url : FtpMetricsUtil.UNKNOWN);
+            ctx.addTag(FtpObserverContext.TAG_PROTOCOL, protocol != null ? protocol : FtpMetricsUtil.UNKNOWN);
+            String instanceUrl = FtpMetricsUtil.getInstanceUrl();
+            if (instanceUrl != null) {
+                ctx.addTag(FtpObserverContext.TAG_INSTANCE_URL, instanceUrl);
+            }
+        } catch (Throwable t) {
+            log.debug("Failed to send poll metrics data", t);
+        }
+    }
+
+    /**
+     * Adds the outcome tag to the poll span on the current frame.
+     *
+     * @param env     the current Ballerina environment
+     * @param outcome success or failure
+     */
+    public static void sendPollOutcome(Environment env, String outcome) {
+        try {
+            ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
+            if (ctx == null) {
+                return;
+            }
+            ctx.addTag(FtpObserverContext.TAG_OUTCOME, outcome);
+        } catch (Throwable t) {
+            log.debug("Failed to send poll outcome", t);
         }
     }
 
@@ -173,11 +427,52 @@ public class FtpTracingUtil {
      * @param errorType Ballerina error type name (e.g. {@code "ConnectionError"})
      */
     public static void sendErrorMetricsOnCurrentFrame(Environment env, String errorType) {
-        ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
-        if (ctx == null) {
+        try {
+            ObserverContext ctx = ObserveUtils.getObserverContextOfCurrentFrame(env);
+            if (ctx == null) {
+                return;
+            }
+            ctx.addTag(ObservabilityConstants.TAG_KEY_ERROR, ObservabilityConstants.TAG_TRUE_VALUE);
+            ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
+            ctx.addTag(FtpObserverContext.TAG_OUTCOME, FtpMetricsUtil.OUTCOME_FAILURE);
+        } catch (Throwable t) {
+            log.debug("Failed to send error metrics on current frame", t);
+        }
+    }
+
+    /**
+     * Adds file.size and file.modified_time as span-only tags to strand properties.
+     * These are trace-only to avoid metric cardinality explosion.
+     *
+     * @param strandProperties the strand properties map (may be null)
+     * @param fileSize         file size in bytes, or -1 if unknown
+     * @param modifiedTime     last-modified timestamp, or -1 if unknown
+     * @param filePath         file path for span-only tag
+     */
+    public static void addFileMetadataToStrandProperties(Map<String, Object> strandProperties,
+                                                          long fileSize, long modifiedTime, String filePath) {
+        if (strandProperties == null) {
             return;
         }
-        ctx.addTag(ObservabilityConstants.TAG_KEY_ERROR, ObservabilityConstants.TAG_TRUE_VALUE);
-        ctx.addTag(FtpObserverContext.TAG_ERROR_TYPE, errorType);
+        try {
+            FtpObserverContext ctx = (FtpObserverContext) strandProperties.get(
+                    ObservabilityConstants.KEY_OBSERVER_CONTEXT);
+            if (ctx == null) {
+                return;
+            }
+            // These are stored as properties and will be added as span-only tags
+            // when the span is available (after strand starts)
+            if (fileSize >= 0) {
+                ctx.addProperty(FtpObserverContext.TAG_FILE_SIZE, fileSize);
+            }
+            if (modifiedTime >= 0) {
+                ctx.addProperty(FtpObserverContext.TAG_FILE_MODIFIED_TIME, modifiedTime);
+            }
+            if (filePath != null) {
+                ctx.addProperty(FtpObserverContext.TAG_FILE_PATH, filePath);
+            }
+        } catch (Throwable t) {
+            log.debug("Failed to add file metadata to strand properties", t);
+        }
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpContentCallbackHandler.java
@@ -39,6 +39,7 @@ import io.ballerina.stdlib.ftp.ContentByteStreamIteratorUtils;
 import io.ballerina.stdlib.ftp.ContentCsvStreamIteratorUtils;
 import io.ballerina.stdlib.ftp.client.FtpRetryHelper;
 import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
+import io.ballerina.stdlib.ftp.observability.FtpObserverContext;
 import io.ballerina.stdlib.ftp.observability.FtpTracingUtil;
 import io.ballerina.stdlib.ftp.transport.message.FileInfo;
 import io.ballerina.stdlib.ftp.transport.message.RemoteFileSystemEvent;
@@ -121,6 +122,7 @@ public class FtpContentCallbackHandler {
         String listenerPath = event.getSourcePath();
 
         for (FileInfo fileInfo : addedFiles) {
+            FtpObserverContext parentCtx = null;
             try {
                 // Route file to appropriate method
                 Optional<MethodType> methodTypeOpt = holder.getMethod(fileInfo);
@@ -128,24 +130,51 @@ public class FtpContentCallbackHandler {
                 if (methodTypeOpt.isEmpty()) {
                     log.warn("No content handler method found for file: {}. Skipping content processing.",
                             fileInfo.getPath());
+                    // Single increment for skipped file: file.stage=found, outcome=skipped
+                    FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                            FtpMetricsUtil.FILE_STAGE_FOUND, FtpMetricsUtil.OUTCOME_SKIPPED,
+                            FtpMetricsUtil.FAILURE_NO_HANDLER_MATCHED, null);
                     continue;
                 }
 
                 String fileUri = fileInfo.getPath();
+                MethodType methodType = methodTypeOpt.get();
+
+                // Create per-file parent span covering the entire lifecycle
+                parentCtx = FtpTracingUtil.createFileLifecycleContext(
+                        listenerUrl, listenerProtocol, fileUri);
+
+                // Stage 1: File found and matched to a handler
+                FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                        FtpMetricsUtil.FILE_STAGE_FOUND, null, null, null);
+
+                // Stage 2: File dispatched — matched to a handler
+                FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                        FtpMetricsUtil.FILE_STAGE_DISPATCHED, null, null, methodType.getName());
 
                 // Convert content based on method signature (retry is handled inside)
-                MethodType methodType = methodTypeOpt.get();
+                long bindingStart = System.nanoTime();
                 Object convertedContent = convertFileContent(env, fileUri, methodType);
+                long bindingDurationMs = (System.nanoTime() - bindingStart) / 1_000_000;
 
                 if (convertedContent instanceof BError bError) {
+                    FtpMetricsUtil.reportDatabindingDuration(listenerUrl, listenerProtocol,
+                            methodType.getName(), FtpMetricsUtil.OUTCOME_FAILURE, bindingDurationMs);
                     if (FtpUtil.ErrorType.ContentBindingError.errorType().equals(bError.getType().getName())) {
+                        // parentCtx ownership transfers to routeToOnError — it finishes the span
                         routeToOnError(service, holder, bError, callerObject, fileInfo, listenerPath,
-                                methodType.getName());
+                                methodType.getName(), parentCtx);
+                        parentCtx = null;
                     } else {
                         bError.printStackTrace();
+                        FtpTracingUtil.finishFileLifecycleSpan(parentCtx);
+                        parentCtx = null;
                     }
                     continue;
                 }
+
+                FtpMetricsUtil.reportDatabindingDuration(listenerUrl, listenerProtocol,
+                        methodType.getName(), FtpMetricsUtil.OUTCOME_SUCCESS, bindingDurationMs);
 
                 // Prepare method arguments
                 Object[] methodArguments = prepareContentMethodArguments(methodType, convertedContent,
@@ -155,17 +184,26 @@ public class FtpContentCallbackHandler {
                 Optional<PostProcessAction> afterProcess = holder.getAfterProcessAction(methodType.getName());
                 Optional<PostProcessAction> afterError = holder.getAfterErrorAction(methodType.getName());
 
-                Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
+                // Stage 3: Create strand properties with file stage=handled, handler name, and file metadata
+                Map<String, Object> strandProperties = FtpTracingUtil.createFileStageStrandProperties(
                         FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
-                        FtpMetricsUtil.EVENT_TYPE_CHANGE, fileUri);
+                        FtpMetricsUtil.EVENT_TYPE_CHANGE, FtpMetricsUtil.FILE_STAGE_HANDLED,
+                        methodType.getName(), fileInfo.getFileSize(), fileInfo.getLastModifiedTime());
+                FtpTracingUtil.addFileMetadataToStrandProperties(strandProperties,
+                        fileInfo.getFileSize(), fileInfo.getLastModifiedTime(), fileUri);
+                // Wire handled span as a child of the per-file parent span
+                FtpTracingUtil.setParentContext(strandProperties, parentCtx);
 
-                // Invoke method asynchronously with post-processing
+                // parentCtx ownership transfers to invokeContentMethodAsync — it finishes the span
                 invokeContentMethodAsync(service, methodType.getName(), methodArguments,
-                        fileInfo, callerObject, listenerPath, afterProcess, afterError, strandProperties);
+                        fileInfo, callerObject, listenerPath, afterProcess, afterError,
+                        strandProperties, parentCtx);
+                parentCtx = null;
 
             } catch (Exception exception) {
                 FtpUtil.createError("Failed to process file: " + fileInfo.getPath() + " - " + exception.getMessage(),
                         exception, FtpConstants.FTP_ERROR).printStackTrace();
+                FtpTracingUtil.finishFileLifecycleSpan(parentCtx);
                 // Continue processing other files even if one fails
             }
         }
@@ -216,6 +254,9 @@ public class FtpContentCallbackHandler {
             fo = fileSystemManager.resolveFile(fileUri, fileSystemOptions);
             is = fo.getContent().getInputStream();
             byte[] fileContent = FtpContentConverter.convertInputStreamToByteArray(is);
+            // Report bytes transferred for listener content reads
+            FtpMetricsUtil.reportBytesTransferred(listenerUrl, listenerProtocol,
+                    FtpMetricsUtil.CONTEXT_LISTENER, FtpMetricsUtil.OPERATION_TYPE_GET, fileContent.length);
             return switch (methodName) {
                 case ON_FILE_REMOTE_FUNCTION -> convertToBallerinaByteArray(fileContent);
                 case ON_FILE_TEXT_REMOTE_FUNCTION -> convertBytesToString(fileContent);
@@ -317,15 +358,24 @@ public class FtpContentCallbackHandler {
     }
 
     private void routeToOnError(BObject service, FormatMethodsHolder holder, BError error, BObject callerObject,
-                                FileInfo fileInfo, String listenerPath, String contentMethodName) {
+                                FileInfo fileInfo, String listenerPath, String contentMethodName,
+                                FtpObserverContext parentCtx) {
         Optional<MethodType> onErrorMethodOpt = holder.getOnErrorMethod();
         if (onErrorMethodOpt.isEmpty()) {
             // No onError handler — fall back to the content method's afterError so the
             // corrupted source file does not get re-picked on every poll.
             error.printStackTrace();
-            holder.getAfterErrorAction(contentMethodName).ifPresent(action ->
-                    Thread.startVirtualThread(() -> executePostProcessAction(action, fileInfo,
-                            callerObject, listenerPath, ACTION_AFTER_ERROR)));
+            Optional<PostProcessAction> afterErrorAction = holder.getAfterErrorAction(contentMethodName);
+            if (afterErrorAction.isPresent()) {
+                final FtpObserverContext ctx = parentCtx;
+                Thread.startVirtualThread(() -> {
+                    executePostProcessAction(afterErrorAction.get(), fileInfo,
+                            callerObject, listenerPath, ACTION_AFTER_ERROR, contentMethodName, ctx);
+                    FtpTracingUtil.finishFileLifecycleSpan(ctx);
+                });
+            } else {
+                FtpTracingUtil.finishFileLifecycleSpan(parentCtx);
+            }
             return;
         }
 
@@ -339,13 +389,17 @@ public class FtpContentCallbackHandler {
         Map<String, Object> strandProperties = FtpTracingUtil.createErrorStrandProperties(
                 FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
                 fileInfo.getPath(), errorType);
+        // Tag this as a handled stage with failure outcome and binding error type
+        FtpTracingUtil.addOutcomeToStrandProperties(strandProperties,
+                FtpMetricsUtil.OUTCOME_FAILURE, FtpMetricsUtil.FAILURE_BINDING_FAILED);
+        FtpTracingUtil.setParentContext(strandProperties, parentCtx);
 
         Object[] methodArguments = prepareOnErrorMethodArguments(onErrorMethod, error, callerObject);
         invokeOnErrorMethodAsync(service, onErrorMethod.getName(), methodArguments, fileInfo, callerObject,
                 listenerPath,
                 hasOnErrorActions ? onErrorAfterProcess : Optional.empty(),
                 hasOnErrorActions ? onErrorAfterError : Optional.empty(),
-                strandProperties);
+                strandProperties, parentCtx);
     }
 
     private Object[] prepareOnErrorMethodArguments(MethodType methodType, BError error, BObject callerObject) {
@@ -364,7 +418,8 @@ public class FtpContentCallbackHandler {
                                           FileInfo fileInfo, BObject callerObject, String listenerPath,
                                           Optional<PostProcessAction> afterProcess,
                                           Optional<PostProcessAction> afterError,
-                                          Map<String, Object> strandProperties) {
+                                          Map<String, Object> strandProperties,
+                                          FtpObserverContext parentCtx) {
         Thread.startVirtualThread(() -> {
             boolean isSuccess = false;
             try {
@@ -387,11 +442,12 @@ public class FtpContentCallbackHandler {
 
             if (isSuccess) {
                 afterProcess.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, ACTION_AFTER_PROCESS));
+                        listenerPath, ACTION_AFTER_PROCESS, methodName, parentCtx));
             } else {
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, ACTION_AFTER_ERROR));
+                        listenerPath, ACTION_AFTER_ERROR, methodName, parentCtx));
             }
+            FtpTracingUtil.finishFileLifecycleSpan(parentCtx);
         });
     }
 
@@ -399,62 +455,107 @@ public class FtpContentCallbackHandler {
                                           FileInfo fileInfo, BObject callerObject, String listenerPath,
                                           Optional<PostProcessAction> afterProcess,
                                           Optional<PostProcessAction> afterError,
-                                          Map<String, Object> strandProperties) {
+                                          Map<String, Object> strandProperties,
+                                          FtpObserverContext parentCtx) {
         Thread.startVirtualThread(() -> {
             boolean isSuccess = false;
+            long execStart = System.nanoTime();
             try {
                 ObjectType serviceType = (ObjectType) TypeUtils.getReferredType(TypeUtils.getType(service));
                 boolean isConcurrentSafe = serviceType.isIsolated() && serviceType.isIsolated(methodName);
+                // Add outcome=success preemptively; overwritten on failure
+                FtpTracingUtil.addOutcomeToStrandProperties(strandProperties,
+                        FtpMetricsUtil.OUTCOME_SUCCESS, null);
                 StrandMetadata strandMetadata = new StrandMetadata(isConcurrentSafe, strandProperties);
 
                 Object result = ballerinaRuntime.callMethod(service, methodName, strandMetadata, methodArguments);
+                long execDurationMs = (System.nanoTime() - execStart) / 1_000_000;
 
-                if (result instanceof BError) {
-                    ((BError) result).printStackTrace();
+                if (result instanceof BError bError) {
+                    bError.printStackTrace();
+                    String errorType = bError.getType() != null
+                            ? bError.getType().getName() : FtpMetricsUtil.UNKNOWN;
+                    FtpTracingUtil.addOutcomeToStrandProperties(strandProperties,
+                            FtpMetricsUtil.OUTCOME_FAILURE, null);
+                    FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                            FtpMetricsUtil.FILE_STAGE_HANDLED, FtpMetricsUtil.OUTCOME_FAILURE,
+                            errorType, methodName);
+                    FtpMetricsUtil.reportResourceExecutionDuration(listenerUrl, listenerProtocol,
+                            methodName, FtpMetricsUtil.OUTCOME_FAILURE, execDurationMs);
                     // Method returned an error - execute afterError action
                     afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                            listenerPath, ACTION_AFTER_ERROR));
+                            listenerPath, ACTION_AFTER_ERROR, methodName, parentCtx));
                 } else {
                     isSuccess = true;
+                    FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                            FtpMetricsUtil.FILE_STAGE_HANDLED, FtpMetricsUtil.OUTCOME_SUCCESS,
+                            null, methodName);
+                    FtpMetricsUtil.reportResourceExecutionDuration(listenerUrl, listenerProtocol,
+                            methodName, FtpMetricsUtil.OUTCOME_SUCCESS, execDurationMs);
                 }
             } catch (BError error) {
+                long execDurationMs = (System.nanoTime() - execStart) / 1_000_000;
                 error.printStackTrace();
+                String errorType = error.getType() != null
+                        ? error.getType().getName() : FtpMetricsUtil.UNKNOWN;
+                FtpTracingUtil.addOutcomeToStrandProperties(strandProperties,
+                        FtpMetricsUtil.OUTCOME_FAILURE, null);
+                FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                        FtpMetricsUtil.FILE_STAGE_HANDLED, FtpMetricsUtil.OUTCOME_FAILURE,
+                        errorType, methodName);
+                FtpMetricsUtil.reportResourceExecutionDuration(listenerUrl, listenerProtocol,
+                        methodName, FtpMetricsUtil.OUTCOME_FAILURE, execDurationMs);
                 // Method threw an error - execute afterError action
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, ACTION_AFTER_ERROR));
+                        listenerPath, ACTION_AFTER_ERROR, methodName, parentCtx));
             } catch (Exception exception) {
+                long execDurationMs = (System.nanoTime() - execStart) / 1_000_000;
                 FtpUtil.createError("Error invoking content method: " + methodName + " - " + exception.getMessage(),
                         exception, FtpConstants.FTP_ERROR).printStackTrace();
+                FtpTracingUtil.addOutcomeToStrandProperties(strandProperties,
+                        FtpMetricsUtil.OUTCOME_FAILURE, null);
+                FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                        FtpMetricsUtil.FILE_STAGE_HANDLED, FtpMetricsUtil.OUTCOME_FAILURE,
+                        exception.getClass().getSimpleName(), methodName);
+                FtpMetricsUtil.reportResourceExecutionDuration(listenerUrl, listenerProtocol,
+                        methodName, FtpMetricsUtil.OUTCOME_FAILURE, execDurationMs);
                 // Method threw an exception - execute afterError action
                 afterError.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, ACTION_AFTER_ERROR));
+                        listenerPath, ACTION_AFTER_ERROR, methodName, parentCtx));
             }
 
             // Execute afterProcess action on success
             if (isSuccess) {
                 afterProcess.ifPresent(action -> executePostProcessAction(action, fileInfo, callerObject,
-                        listenerPath, ACTION_AFTER_PROCESS));
+                        listenerPath, ACTION_AFTER_PROCESS, methodName, parentCtx));
             }
+            FtpTracingUtil.finishFileLifecycleSpan(parentCtx);
         });
     }
 
     private void executePostProcessAction(PostProcessAction action, FileInfo fileInfo, BObject callerObject,
-                                          String listenerPath, String actionContext) {
+                                          String listenerPath, String actionContext, String handlerName,
+                                          FtpObserverContext parentCtx) {
 
         String filePath;
         try {
             filePath = fileInfo.getFileName().getPathDecoded();
         } catch (Exception e) {
-            log.warn("Cannot execute {} action: Failed to retrieve file path from FileInfo: {}", actionContext, 
+            log.warn("Cannot execute {} action: Failed to retrieve file path from FileInfo: {}", actionContext,
             e.getMessage());
             return;
         }
 
+        String cleanupAction = action.isDelete() ? FtpMetricsUtil.CLEANUP_ACTION_DELETE
+                : FtpMetricsUtil.CLEANUP_ACTION_MOVE;
+
         try {
             if (action.isDelete()) {
-                executeDeleteAction(callerObject, filePath, actionContext);
+                executeDeleteAction(callerObject, filePath, listenerPath, actionContext, handlerName,
+                        cleanupAction, parentCtx);
             } else if (action.isMove()) {
-                executeMoveAction(callerObject, filePath, listenerPath, action, actionContext);
+                executeMoveAction(callerObject, filePath, listenerPath, action, actionContext,
+                        handlerName, cleanupAction, parentCtx);
             }
         } catch (Exception e) {
             FtpUtil.createError("Failed to execute " + actionContext + " action on file: " + filePath +
@@ -462,17 +563,33 @@ public class FtpContentCallbackHandler {
         }
     }
 
-    private void executeDeleteAction(BObject callerObject, String filePath, String actionContext) {
+    private void executeDeleteAction(BObject callerObject, String filePath, String listenerPath,
+                                     String actionContext, String handlerName, String cleanupAction,
+                                     FtpObserverContext parentCtx) {
         try {
             BObject clientObj = callerObject.getObjectValue(StringUtils.fromString("client"));
-            StrandMetadata strandMetadata = new StrandMetadata(true, null);
+            Map<String, Object> cleanupProps = FtpTracingUtil.createCleanupStrandProperties(
+                    FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
+                    cleanupAction, handlerName);
+            FtpTracingUtil.setParentContext(cleanupProps, parentCtx);
+            StrandMetadata strandMetadata = new StrandMetadata(true, cleanupProps);
             Object result = ballerinaRuntime.callMethod(clientObj, "delete", strandMetadata,
                     StringUtils.fromString(filePath));
 
             if (result instanceof BError) {
                 ((BError) result).printStackTrace();
+                FtpTracingUtil.addOutcomeToStrandProperties(cleanupProps,
+                        FtpMetricsUtil.OUTCOME_FAILURE, FtpMetricsUtil.FAILURE_DELETE_FAILED);
+                FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                        FtpMetricsUtil.FILE_STAGE_CLEANED_UP, FtpMetricsUtil.OUTCOME_FAILURE,
+                        FtpMetricsUtil.FAILURE_DELETE_FAILED, handlerName);
             } else {
                 log.debug("Successfully deleted file during {}: {}", actionContext, filePath);
+                FtpTracingUtil.addOutcomeToStrandProperties(cleanupProps,
+                        FtpMetricsUtil.OUTCOME_SUCCESS, null);
+                FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                        FtpMetricsUtil.FILE_STAGE_CLEANED_UP, FtpMetricsUtil.OUTCOME_SUCCESS,
+                        null, handlerName);
             }
         } catch (Exception e) {
             FtpUtil.createError("Exception during delete action (" + actionContext + "): " + filePath +
@@ -480,20 +597,36 @@ public class FtpContentCallbackHandler {
         }
     }
 
-    private void executeMoveAction(BObject callerObject, String filePath, String listenerPath,
-                                   PostProcessAction action, String actionContext) {
+    private void executeMoveAction(BObject callerObject, String filePath,
+                                   String listenerPath, PostProcessAction action,
+                                   String actionContext, String handlerName, String cleanupAction,
+                                   FtpObserverContext parentCtx) {
         try {
             String destinationPath = calculateMoveDestination(filePath, listenerPath, action);
 
             BObject clientObj = callerObject.getObjectValue(StringUtils.fromString("client"));
-            StrandMetadata strandMetadata = new StrandMetadata(true, null);
+            Map<String, Object> cleanupProps = FtpTracingUtil.createCleanupStrandProperties(
+                    FtpMetricsUtil.CONTEXT_LISTENER, listenerUrl, listenerProtocol,
+                    cleanupAction, handlerName);
+            FtpTracingUtil.setParentContext(cleanupProps, parentCtx);
+            StrandMetadata strandMetadata = new StrandMetadata(true, cleanupProps);
             Object result = ballerinaRuntime.callMethod(clientObj, "move", strandMetadata,
                     StringUtils.fromString(filePath), StringUtils.fromString(destinationPath));
 
             if (result instanceof BError) {
                 ((BError) result).printStackTrace();
+                FtpTracingUtil.addOutcomeToStrandProperties(cleanupProps,
+                        FtpMetricsUtil.OUTCOME_FAILURE, FtpMetricsUtil.FAILURE_MOVE_FAILED);
+                FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                        FtpMetricsUtil.FILE_STAGE_CLEANED_UP, FtpMetricsUtil.OUTCOME_FAILURE,
+                        FtpMetricsUtil.FAILURE_MOVE_FAILED, handlerName);
             } else {
                 log.debug("Successfully moved file during {}: {} -> {}", actionContext, filePath, destinationPath);
+                FtpTracingUtil.addOutcomeToStrandProperties(cleanupProps,
+                        FtpMetricsUtil.OUTCOME_SUCCESS, null);
+                FtpMetricsUtil.reportFileStage(listenerUrl, listenerProtocol, listenerPath,
+                        FtpMetricsUtil.FILE_STAGE_CLEANED_UP, FtpMetricsUtil.OUTCOME_SUCCESS,
+                        null, handlerName);
             }
         } catch (Exception e) {
             FtpUtil.createError("Exception during move action (" + actionContext + "): " + filePath +

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListener.java
@@ -39,6 +39,7 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.stdlib.ftp.exception.FtpInvalidConfigException;
 import io.ballerina.stdlib.ftp.exception.RemoteFileSystemConnectorException;
+import io.ballerina.stdlib.ftp.observability.FtpMetricsUtil;
 import io.ballerina.stdlib.ftp.observability.FtpTracingUtil;
 import io.ballerina.stdlib.ftp.transport.listener.RemoteFileSystemListener;
 import io.ballerina.stdlib.ftp.transport.message.FileInfo;
@@ -264,8 +265,9 @@ public class FtpListener implements RemoteFileSystemListener {
             BString deletedFileBString = StringUtils.fromString(deletedFile);
             Object[] args = getOnFileDeleteMethodArguments(params, deletedFileBString, caller);
             if (args != null) {
-                Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
-                        CONTEXT_LISTENER, listenerUrl, listenerProtocol, EVENT_TYPE_DELETE, deletedFile);
+                Map<String, Object> strandProperties = FtpTracingUtil.createFileStageStrandProperties(
+                        CONTEXT_LISTENER, listenerUrl, listenerProtocol, EVENT_TYPE_DELETE,
+                        FtpMetricsUtil.FILE_STAGE_HANDLED, methodType.getName(), -1, -1);
                 invokeOnFileDeleteAsync(service, strandProperties, args);
             }
         }
@@ -289,8 +291,9 @@ public class FtpListener implements RemoteFileSystemListener {
         Parameter[] params = methodType.getParameters();
         Object[] args = getOnFileDeletedMethodArguments(params, deletedFilesArray, caller);
         if (args != null) {
-            Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
-                    CONTEXT_LISTENER, listenerUrl, listenerProtocol, EVENT_TYPE_DELETE);
+            Map<String, Object> strandProperties = FtpTracingUtil.createFileStageStrandProperties(
+                    CONTEXT_LISTENER, listenerUrl, listenerProtocol, EVENT_TYPE_DELETE,
+                    FtpMetricsUtil.FILE_STAGE_HANDLED, methodType.getName(), -1, -1);
             invokeOnFileDeletedAsync(service, strandProperties, args);
         }
     }
@@ -305,8 +308,9 @@ public class FtpListener implements RemoteFileSystemListener {
         Object[] args = getMethodArguments(params, watchEventParamValues, caller);
         if (args != null) {
             String traceEventType = event.getAddedFiles().isEmpty() ? EVENT_TYPE_DELETE : EVENT_TYPE_CHANGE;
-            Map<String, Object> strandProperties = FtpTracingUtil.createStrandProperties(
-                    CONTEXT_LISTENER, listenerUrl, listenerProtocol, traceEventType);
+            Map<String, Object> strandProperties = FtpTracingUtil.createFileStageStrandProperties(
+                    CONTEXT_LISTENER, listenerUrl, listenerProtocol, traceEventType,
+                    FtpMetricsUtil.FILE_STAGE_HANDLED, methodType.getName(), -1, -1);
             invokeMethodAsync(service, strandProperties, args);
         }
     }

--- a/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/ftp/server/FtpListenerHelper.java
@@ -140,7 +140,7 @@ public class FtpListenerHelper {
                     .getIntValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_PORT)));
             String protocol = serviceEndpointConfig
                     .getStringValue(StringUtils.fromString(FtpConstants.ENDPOINT_CONFIG_PROTOCOL)).getValue();
-            String url = protocol + "://" + host + ":" + port;
+            String url = host + ":" + port;
             listener.setListenerUrl(url);
             listener.setListenerProtocol(protocol);
 
@@ -833,16 +833,22 @@ public class FtpListenerHelper {
         }
     }
 
-    public static Object poll(BObject ftpListener) {
+    public static Object poll(Environment env, BObject ftpListener) {
         RemoteFileSystemServerConnector connector = (RemoteFileSystemServerConnector) ftpListener.
                 getNativeData(FtpConstants.FTP_SERVER_CONNECTOR);
         if (connector == null) {
             return FtpUtil.createError("FTP listener is not initialized. Attach a service before polling.",
                     null, Error.errorType());
         }
+        FtpListener listener = connector.getFtpListener();
+        String listenerUrl = listener != null ? listener.getListenerUrl() : null;
+        String listenerProtocol = listener != null ? listener.getListenerProtocol() : null;
+
         try {
             connector.poll();
+            FtpMetricsUtil.reportPollCycle(listenerUrl, listenerProtocol, null, FtpMetricsUtil.OUTCOME_SUCCESS);
         } catch (RemoteFileSystemConnectorException e) {
+            FtpMetricsUtil.reportPollCycle(listenerUrl, listenerProtocol, null, FtpMetricsUtil.OUTCOME_FAILURE);
             return FtpUtil.createError("Error during the poll operation: " + e.getMessage(),
                     findRootCause(e), Error.errorType());
         }


### PR DESCRIPTION
## Purpose

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added unified FTP observability metrics, tags, outcomes, and duration reporting.
- Added client byte-transfer metrics and success tracing.
- Added file lifecycle tracing for polling, dispatch, handling, and cleanup.
- Added resilient observability handling for reporting failures.
- Renamed the `admin` operation type to `manage`.
- Updated the observability specification and `io` dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->