### PR TITLE
Update header formatting in README.md

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -2,7 +2,7 @@
 
 This module provides an FTP/SFTP client and an FTP/SFTP server listener implementation to facilitate an FTP/SFTP connection connected to a remote location. Additionally, it supports FTPS (FTP over SSL/TLS) to facilitate secure file transfers.
 
-## Key Features
+### Key Features
 
 - FTP/SFTP client for remote file operations
 - FTP/SFTP server listener for reacting to file events


### PR DESCRIPTION
## Purpose

Fixes the README so the WSO2 Integration Store correctly displays the Key Features section for this connector. `## Key Features` is demoted to `### Key Features`, nesting it under `## Overview` to match the Store's existing parsing convention.

## Examples

N/A — documentation-only change, no code or behavior affected.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
- [ ] Checked the impact on OpenAPI generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Changed the `Key Features` heading in `ballerina/README.md` from `##` to `###`.
- Nested the section under `## Overview` to improve display in the WSO2 Integration Store.
- No code or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->